### PR TITLE
Sign the built-in SideStore in automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to iPASide are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and
 [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- **SideStore reuses iPASide's certificate instead of replacing it.** The SideStore built
+  into the LiveContainer build now carries iPASide's own signing identity, baked into its
+  bundle the way iLoader's isideload does: `ALTCertificate.p12` encrypted with the
+  certificate's Apple `machineId`, plus `ALTCertificateID` and `ALTAppGroups` in the
+  framework `Info.plist`. When you sign into that SideStore with the **same** Apple ID
+  iPASide uses, it matches the serial, decrypts the identity and reuses it - so the two
+  share one certificate, nothing iPASide already signed is invalidated, and no extra
+  certificate slot is spent.
+
+  This does **not** remove SideStore's sign-in, and it was a mistake to describe it that
+  way while building it. SideStore needs an Apple session of its own to reach Apple's
+  developer API when it refreshes; a certificate is an identity, not a session. The
+  on-device refresh flow is: install the SideStore build, open it and sign in once with the
+  same Apple ID, connect a local device VPN, then refresh. The LiveContainer tab now states
+  the sign-in step first. Signing in with a *different* Apple ID makes SideStore mint its
+  own certificate and a second LiveContainer along with it.
+
 ## [1.1.1] - 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@ There is a full light theme too, and the sun in the title bar switches to it.
   expiry of their own. Verified end to end on an iPhone 8 Plus with a free Apple ID.
 - **Refresh on the phone, no PC.** iPASide installs the LiveContainer build that carries
   SideStore and hands it this computer's pairing file, so the phone can re-sign its own
-  apps. It needs a local device VPN connected, and an iOS Shortcut named `TurnOffData`
-  that iPASide cannot create for you — the app says so rather than letting you find out.
+  apps. You sign into that SideStore once, with the same Apple ID iPASide uses — iPASide
+  bakes its certificate in, so SideStore reuses that identity instead of replacing it. It
+  also needs a local device VPN connected, and an iOS Shortcut named `TurnOffData` that
+  iPASide cannot create for you — the app says all of this rather than letting you find out.
 - **See and manage your Apple ID's account.** Certificates, App IDs and devices, for any
   Apple ID you have signed in. Each certificate says which tool registered it, because
   Apple counts them per machine and revoking the wrong one breaks a different tool's apps.

--- a/src/iPASide.Engine/ipaside_engine/livecontainer.py
+++ b/src/iPASide.Engine/ipaside_engine/livecontainer.py
@@ -32,6 +32,7 @@ import plistlib
 import shutil
 import tempfile
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
@@ -96,6 +97,16 @@ SIGNIN_REQUEST_NAME = "iPASide-signin.plist"
 #: SideStore's keychain service, exactly as AltStoreCore/Keychain.swift opens it (its
 #: hardcoded bundle id). Handed to the dylib so what it writes is what SideStore reads.
 SIDESTORE_KEYCHAIN_SERVICE = "com.SideStore.SideStore"
+
+#: SideStore's home inside LiveContainer (LiveContainer redirects the guest's HOME here),
+#: and its standard-defaults plist under it. SideStore's AppDelegate resets the keychain -
+#: wiping the seeded tokens - the first time it launches, gated on ``firstLaunch`` being
+#: absent from these defaults. Pre-setting the key makes it skip that reset, so the seed
+#: survives. On a fresh install nothing has written this domain yet, so the value written
+#: to disk here is what it reads on that first launch.
+SIDESTORE_HOME = "/Documents/SideStore"
+_SIDESTORE_PREFS = f"{SIDESTORE_HOME}/Library/Preferences/com.SideStore.SideStore.plist"
+_FIRST_LAUNCH_KEY = "firstLaunch"
 
 #: Release builds. The SideStore one carries a whole store inside the same bundle id, so
 #: it costs no extra app slot, and its refresh is exposed as an App Intent - meaning a
@@ -656,13 +667,61 @@ def deliver_signin(bundle: dict[str, Any], serial: str | None = None) -> dict[st
         return {"seeded": False, "automatic": False, "error": str(exc)}
 
     try:
-        asyncio.run(
-            _write_documents(bundle["bundle_id"], serial, {SIGNIN_REQUEST_NAME: request})
+        suppressed = asyncio.run(
+            _seed_signin_async(bundle["bundle_id"], serial, request)
         )
     except Exception as exc:  # noqa: BLE001 - any transport failure means the same thing
         return {"seeded": False, "automatic": False, "error": str(exc)}
 
-    return {"seeded": True, "automatic": True}
+    return {"seeded": True, "automatic": True, "first_launch_suppressed": suppressed}
+
+
+async def _seed_signin_async(bundle_id: str, serial: str | None, request: bytes) -> bool:
+    """Deliver the token request and suppress the first-launch reset in one session.
+
+    Both are needed for the seed to take: the dylib imports the tokens from the request,
+    but SideStore's AppDelegate resets the keychain the first time it launches - erasing
+    them - unless ``firstLaunch`` is already set. Returns whether that key is now in place.
+    """
+    from pymobiledevice3.services.house_arrest import HouseArrestService
+
+    client = await lockdown.create(serial)
+    try:
+        async with await HouseArrestService.create(client, bundle_id) as svc:
+            await svc.makedirs("/Documents")
+            await svc.set_file_contents(f"/Documents/{SIGNIN_REQUEST_NAME}", request)
+            return await _suppress_first_launch(svc)
+    finally:
+        await lockdown.close(client)
+
+
+async def _suppress_first_launch(svc: Any) -> bool:
+    """Set SideStore's ``firstLaunch`` default so it does not reset the keychain on launch.
+
+    Merges into whatever prefs already exist and leaves an earlier date untouched, so a
+    store that really has launched keeps its own first-launch date. Any read failure just
+    means the file is not there yet, which is the fresh-install case a value is written for.
+    """
+    prefs: dict[str, Any] = {}
+    try:
+        loaded = plistlib.loads(await svc.get_file_contents(_SIDESTORE_PREFS))
+        if isinstance(loaded, dict):
+            prefs = loaded
+    except Exception:  # noqa: BLE001 - absent or unreadable both mean "write a fresh one"
+        prefs = {}
+
+    if prefs.get(_FIRST_LAUNCH_KEY) is not None:
+        return True
+
+    # Naive: plistlib's binary writer subtracts a naive epoch and rejects aware datetimes.
+    # The value only has to be non-nil for SideStore to skip the reset, so UTC-now is fine.
+    prefs[_FIRST_LAUNCH_KEY] = datetime.now(timezone.utc).replace(tzinfo=None)
+    directory = _SIDESTORE_PREFS.rsplit("/", 1)[0]
+    await svc.makedirs(directory)
+    await svc.set_file_contents(
+        _SIDESTORE_PREFS, plistlib.dumps(prefs, fmt=plistlib.FMT_BINARY)
+    )
+    return True
 
 
 # --------------------------------------------------------------------------- #

--- a/src/iPASide.Engine/ipaside_engine/livecontainer.py
+++ b/src/iPASide.Engine/ipaside_engine/livecontainer.py
@@ -37,7 +37,7 @@ from typing import Any, Callable
 
 import requests
 
-from . import apps, ipa as ipa_module, lockdown, provision, signing
+from . import apps, gsa, ipa as ipa_module, lockdown, provision, signing
 from .errors import EngineError
 
 #: LiveContainer's own identifier; the team id is appended for a free account.
@@ -77,13 +77,25 @@ PAIRING_NAME = "ALTPairingFile.mobiledevicepairing"
 #: Where usbmux keeps the pairing records this PC has for its devices.
 _LOCKDOWN_DIR = Path(r"C:\ProgramData\Apple\Lockdown")
 
-#: The SideStore bundled inside the +SideStore build, and the files it reads on first
-#: launch to import a signing certificate without the user having to sign in. Named and
+#: The SideStore bundled inside the +SideStore build, and the files it reads to reuse a
+#: signing certificate instead of minting its own. SideStore still needs a one-time Apple
+#: ID sign-in; when that sign-in uses the *same* Apple ID iPASide did, it finds this baked
+#: identity by serial and reuses it - no revoke, no extra certificate slot. Named and
 #: placed to AltStore/SideStore's own convention, the same one iLoader's isideload uses.
 SIDESTORE_FRAMEWORK = "SideStoreApp.framework"
 ALT_CERTIFICATE_FILE = "ALTCertificate.p12"
 _ALT_CERTIFICATE_ID_KEY = "ALTCertificateID"
 _ALT_APP_GROUPS_KEY = "ALTAppGroups"
+
+#: Sign-in seed for the built-in SideStore. Delivered to LiveContainer's Documents and
+#: consumed by the injected dylib, which writes the two keychain items SideStore reads on
+#: its token-auth path - so it is signed in the moment it opens, with no Apple ID prompt.
+#: Named to iPASide, not SideStore, which never writes it and only reads the keychain.
+SIGNIN_REQUEST_NAME = "iPASide-signin.plist"
+
+#: SideStore's keychain service, exactly as AltStoreCore/Keychain.swift opens it (its
+#: hardcoded bundle id). Handed to the dylib so what it writes is what SideStore reads.
+SIDESTORE_KEYCHAIN_SERVICE = "com.SideStore.SideStore"
 
 #: Release builds. The SideStore one carries a whole store inside the same bundle id, so
 #: it costs no extra app slot, and its refresh is exposed as an App Intent - meaning a
@@ -151,20 +163,25 @@ def is_livecontainer(info: dict[str, Any]) -> bool:
 def seed_sidestore_certificate(ipa_path: str, bundle: dict[str, Any], dest_dir: str) -> str:
     """Bake iPASide's certificate into the bundled SideStore, before the IPA is signed.
 
-    SideStore imports a certificate it finds in its own bundle on first launch, which is
-    how a store gets a signing identity without the user typing an Apple ID into it. iLoader
-    does the same; the convention (confirmed against isideload) is, inside
-    ``Frameworks/SideStoreApp.framework``:
+    When the user signs into SideStore, it compares the certificates Apple returns for the
+    team against an ``ALTCertificateID`` (a serial) in its bundle; on a match it decrypts a
+    bundled ``ALTCertificate.p12`` with that certificate's Apple ``machineId`` and reuses
+    the identity, instead of revoking one to mint its own. iLoader's isideload bakes it the
+    same way; the convention, inside ``Frameworks/SideStoreApp.framework``, is:
 
     * ``ALTCertificate.p12`` - the identity, encrypted with the certificate's Apple
       ``machineId`` as its password;
     * ``Info.plist`` gains ``ALTCertificateID`` (the serial) and ``ALTAppGroups`` (the
       shared app group).
 
-    Seeding it with *iPASide's own* certificate is the point: SideStore then refreshes
-    under the same identity that installed LiveContainer, so the phone can renew apps on
-    its own and there is no separate Apple ID to sign into - which is also the one way to
-    end up with a second, conflicting LiveContainer.
+    Seeding it with *iPASide's own* certificate is the point: when the user signs into
+    SideStore with the same Apple ID iPASide used, SideStore reuses iPASide's certificate
+    rather than revoking it - so the two share one identity, nothing iPASide already signed
+    is invalidated, and no extra certificate slot is spent. It does **not** remove the
+    sign-in: SideStore needs an Apple session of its own to reach Apple's developer API
+    when it refreshes. Signing into SideStore with a *different* Apple ID makes it mint its
+    own certificate on that account - which is one way to end up with a second, conflicting
+    LiveContainer.
 
     Returns the path to a new IPA, written under ``dest_dir``. Must run before signing:
     the files have to be inside the bundle when zsign builds its code-signature manifest,
@@ -579,6 +596,73 @@ def _manual_instructions(bundle: dict[str, Any]) -> str:
         f"On My iPhone \u2192 LiveContainer \u2192 {CERTIFICATE_NAME}, and enter the "
         f"password {bundle['p12_password']}."
     )
+
+
+# --------------------------------------------------------------------------- #
+# Signing the built-in SideStore in, with no Apple ID prompt
+# --------------------------------------------------------------------------- #
+def _signin_request(bundle: dict[str, Any]) -> bytes:
+    """The plist tools/lc-cert-import/ reads to seed SideStore's sign-in tokens.
+
+    SideStore authenticates by token when its keychain already holds an ``adsid`` and the
+    ``com.apple.gs.xcode.auth`` GrandSlam token - the password-less branch of its
+    ``AuthenticationOperation.signIn``. iPASide already has both for the account that
+    signed this LiveContainer, so handing them over is what lets the built-in store open
+    already signed in and refresh with no prompt. The token itself is long-lived (Apple
+    dates it about a year out), so it outlasts every seven-day app expiry in between.
+
+    They go to every keychain group LiveContainer might place SideStore's guest in: it
+    picks one at random per container, and the dylib, running unhooked in the host, writes
+    into all of them so whichever it lands on is covered. This is exactly the
+    :func:`build_entitlements` keychain list, so the seed and the signed entitlements
+    cannot drift apart.
+    """
+    session = gsa.load_session()
+    return plistlib.dumps(
+        {
+            "AppleIDAdsid": session["adsid"],
+            "AppleIDXcodeToken": session["auth_token"],
+            "KeychainService": SIDESTORE_KEYCHAIN_SERVICE,
+            "AccessGroups": build_entitlements(bundle["team_id"], bundle["bundle_id"])[
+                "keychain-access-groups"
+            ],
+        },
+        fmt=plistlib.FMT_BINARY,
+    )
+
+
+def deliver_signin(bundle: dict[str, Any], serial: str | None = None) -> dict[str, Any]:
+    """Seed the built-in SideStore's sign-in, so it opens already signed in.
+
+    Writes the request the injected dylib consumes into LiveContainer's Documents, but only
+    when this build actually ships that dylib: with nothing to consume it, a live account
+    token would sit on the device for nothing, so the seed is skipped and SideStore's own
+    one-time sign-in is left as the way in.
+
+    Never raises. Like the pairing file, LiveContainer is already installed by the time this
+    runs, so a failure to seed is reported rather than allowed to undo the install - the
+    user can still sign into SideStore by hand.
+    """
+    if signing.resolve_helper_dylib() is None:
+        return {
+            "seeded": False,
+            "automatic": False,
+            "reason": "no import helper in this build",
+        }
+
+    try:
+        request = _signin_request(bundle)
+    except gsa.GsaError as exc:
+        return {"seeded": False, "automatic": False, "error": str(exc)}
+
+    try:
+        asyncio.run(
+            _write_documents(bundle["bundle_id"], serial, {SIGNIN_REQUEST_NAME: request})
+        )
+    except Exception as exc:  # noqa: BLE001 - any transport failure means the same thing
+        return {"seeded": False, "automatic": False, "error": str(exc)}
+
+    return {"seeded": True, "automatic": True}
 
 
 # --------------------------------------------------------------------------- #

--- a/src/iPASide.Engine/ipaside_engine/livecontainer.py
+++ b/src/iPASide.Engine/ipaside_engine/livecontainer.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 
 import asyncio
 import plistlib
+import shutil
+import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable
@@ -74,6 +76,14 @@ PAIRING_NAME = "ALTPairingFile.mobiledevicepairing"
 
 #: Where usbmux keeps the pairing records this PC has for its devices.
 _LOCKDOWN_DIR = Path(r"C:\ProgramData\Apple\Lockdown")
+
+#: The SideStore bundled inside the +SideStore build, and the files it reads on first
+#: launch to import a signing certificate without the user having to sign in. Named and
+#: placed to AltStore/SideStore's own convention, the same one iLoader's isideload uses.
+SIDESTORE_FRAMEWORK = "SideStoreApp.framework"
+ALT_CERTIFICATE_FILE = "ALTCertificate.p12"
+_ALT_CERTIFICATE_ID_KEY = "ALTCertificateID"
+_ALT_APP_GROUPS_KEY = "ALTAppGroups"
 
 #: Release builds. The SideStore one carries a whole store inside the same bundle id, so
 #: it costs no extra app slot, and its refresh is exposed as an App Intent - meaning a
@@ -136,6 +146,63 @@ def build_entitlements(team_id: str, bundle_id: str) -> dict[str, Any]:
 def is_livecontainer(info: dict[str, Any]) -> bool:
     """Whether an inspected IPA is LiveContainer."""
     return str(info.get("bundle_id") or "").startswith(BUNDLE_PREFIX)
+
+
+def seed_sidestore_certificate(ipa_path: str, bundle: dict[str, Any], dest_dir: str) -> str:
+    """Bake iPASide's certificate into the bundled SideStore, before the IPA is signed.
+
+    SideStore imports a certificate it finds in its own bundle on first launch, which is
+    how a store gets a signing identity without the user typing an Apple ID into it. iLoader
+    does the same; the convention (confirmed against isideload) is, inside
+    ``Frameworks/SideStoreApp.framework``:
+
+    * ``ALTCertificate.p12`` - the identity, encrypted with the certificate's Apple
+      ``machineId`` as its password;
+    * ``Info.plist`` gains ``ALTCertificateID`` (the serial) and ``ALTAppGroups`` (the
+      shared app group).
+
+    Seeding it with *iPASide's own* certificate is the point: SideStore then refreshes
+    under the same identity that installed LiveContainer, so the phone can renew apps on
+    its own and there is no separate Apple ID to sign into - which is also the one way to
+    end up with a second, conflicting LiveContainer.
+
+    Returns the path to a new IPA, written under ``dest_dir``. Must run before signing:
+    the files have to be inside the bundle when zsign builds its code-signature manifest,
+    or iOS rejects the framework for having contents the signature does not cover.
+    """
+    key_pem, cert_der, serial = provision.signing_identity()
+    machine_id = provision.certificate_machine_id(bundle["team_id"], serial)
+    alt_p12 = signing.build_p12(cert_der, key_pem, password=machine_id)
+    group = app_group_identifiers(bundle["team_id"])[0]
+
+    work = Path(tempfile.mkdtemp(prefix="ipaside_ss_", dir=dest_dir))
+    try:
+        with zipfile.ZipFile(ipa_path) as archive:
+            archive.extractall(work)
+
+        app = next((work / "Payload").glob("*.app"))
+        framework = app / "Frameworks" / SIDESTORE_FRAMEWORK
+        if not framework.is_dir():
+            raise LiveContainerError(
+                f"{Path(ipa_path).name} has no {SIDESTORE_FRAMEWORK}, so it is not a "
+                "LiveContainer build with SideStore inside it."
+            )
+
+        (framework / ALT_CERTIFICATE_FILE).write_bytes(alt_p12)
+
+        info_path = framework / "Info.plist"
+        info = plistlib.loads(info_path.read_bytes())
+        info[_ALT_CERTIFICATE_ID_KEY] = serial
+        info[_ALT_APP_GROUPS_KEY] = [group]
+        info_path.write_bytes(plistlib.dumps(info, fmt=plistlib.FMT_BINARY))
+
+        # Stored, not deflated: this goes straight back into zsign, which re-reads and
+        # re-zips it anyway, so spending time compressing here is wasted.
+        seeded = Path(dest_dir) / f"{Path(ipa_path).stem}_ss.ipa"
+        ipa_module._zip_dir(work, str(seeded), 0)
+        return str(seeded)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
 
 
 def has_sidestore(ipa_path: str) -> bool:

--- a/src/iPASide.Engine/ipaside_engine/provision.py
+++ b/src/iPASide.Engine/ipaside_engine/provision.py
@@ -57,6 +57,44 @@ def load_bundle() -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def signing_identity() -> tuple[bytes, bytes, str]:
+    """Return ``(private_key_pem, certificate_der, serial)`` for the active account.
+
+    The raw material iPASide signs with, for baking into *another* signer's bundle - see
+    :func:`ipaside_engine.livecontainer.seed_sidestore_certificate`. Read from the same
+    per-account cache the signing bundle uses, so it is the identity that just signed,
+    not a re-issue.
+    """
+    session = gsa.load_session()
+    cache = paths.signing_dir(_account_slug(session.get("email"))) / _CERT_CACHE
+    if not cache.exists():
+        raise gsa.GsaError("no signing certificate cached; run 'provision' first")
+    cached = json.loads(cache.read_text(encoding="utf-8"))
+    return (
+        base64.b64decode(cached["key_pem"]),
+        base64.b64decode(cached["cert_der"]),
+        cached["serial"],
+    )
+
+
+def certificate_machine_id(team_id: str, serial: str) -> str:
+    """The ``machineId`` Apple recorded for a certificate.
+
+    AltStore and SideStore encrypt an imported ``.p12`` with this value as its password -
+    it is the identifier submitted with the CSR, and Apple returns it in the certificate
+    listing. Recovered from there rather than kept locally, so it works for a certificate
+    issued by any earlier build too.
+    """
+    for cert in developer.list_certificates(team_id):
+        if cert.get("serialNumber") == serial:
+            machine_id = cert.get("machineId")
+            if machine_id:
+                return str(machine_id)
+    raise gsa.GsaError(
+        f"could not read the machine id for certificate {serial} from Apple"
+    )
+
+
 def team_scoped_bundle_id(base_bundle_id: str) -> str:
     """Return a bundle id guaranteed registerable on a free account.
 

--- a/src/iPASide.Engine/ipaside_engine/sideload.py
+++ b/src/iPASide.Engine/ipaside_engine/sideload.py
@@ -219,12 +219,15 @@ def _profile_post_install(name: str, udid: str, ipa_path: str) -> dict[str, Any]
         "certificate": livecontainer.seed_certificate(bundle, udid)
     }
 
-    # A pairing file is a credential for this PC's pairing with the phone, so it goes only
-    # to a build that has a store able to use it.
+    # A pairing file is a credential for this PC's pairing with the phone, and the sign-in
+    # tokens are a credential for the Apple account, so both go only to a build with a store
+    # able to use them - and both are re-delivered on every refresh, so a rotated token or a
+    # re-paired device keeps the built-in store working without the user touching it.
     if livecontainer.has_sidestore(ipa_path):
         outcome["pairing"] = livecontainer.deliver_pairing(
             bundle["bundle_id"], udid, udid
         )
+        outcome["signin"] = livecontainer.deliver_signin(bundle, udid)
     return outcome
 
 

--- a/src/iPASide.Engine/ipaside_engine/sideload.py
+++ b/src/iPASide.Engine/ipaside_engine/sideload.py
@@ -174,6 +174,24 @@ def _signing_profile(
     raise SideloadError(f"Unknown signing profile '{name}'.")
 
 
+def _profile_pre_sign(
+    name: str, ipa_path: str, bundle: dict[str, Any], scratch: str
+) -> str | None:
+    """Let a named profile rewrite the bundle before it is signed.
+
+    Returns a new IPA path to sign instead of ``ipa_path``, or None to sign it as-is. Runs
+    after provisioning, so the certificate is available, and before signing, so anything
+    added is covered by the signature. The LiveContainer profile uses this to bake
+    iPASide's certificate into a bundled SideStore; a build without SideStore is left
+    untouched and signs as normal.
+    """
+    from . import livecontainer
+
+    if name == livecontainer.SIGNING_PROFILE and livecontainer.has_sidestore(ipa_path):
+        return livecontainer.seed_sidestore_certificate(ipa_path, bundle, scratch)
+    return None
+
+
 def _profile_post_install(name: str, udid: str, ipa_path: str) -> dict[str, Any] | None:
     """Whatever a named signing profile still has to do once the app is on the device.
 
@@ -372,8 +390,18 @@ def run_sideload(
             written.write_bytes(plistlib.dumps(entitlements))
             entitlements_path = str(written)
 
+        # A profile may rewrite the bundle before it is signed - baking a certificate
+        # into a store it carries, say. Whatever it hands back is what gets signed, so
+        # the added files are covered by the code signature; the seeded copy lives in
+        # scratch and goes with it.
+        sign_source = ipa_path
+        if profile:
+            seeded = _profile_pre_sign(profile, ipa_path, bundle, str(scratch))
+            if seeded:
+                sign_source = seeded
+
         signing.sign_ipa(
-            ipa_path, output,
+            sign_source, output,
             p12_path=bundle["p12_path"],
             p12_password=bundle["p12_password"],
             profile_path=bundle["profile_path"],

--- a/src/iPASide.Flutter/lib/ui/views/live_container_view.dart
+++ b/src/iPASide.Flutter/lib/ui/views/live_container_view.dart
@@ -370,8 +370,19 @@ class _SideStoreCard extends StatelessWidget {
               style: context.t.bodyMuted,
             ),
             const SizedBox(height: Space.s4),
-            // Two things SideStore needs that iPASide cannot provide, said plainly rather
-            // than left for the user to hit as errors.
+            // The steps SideStore needs that iPASide cannot do for it, said plainly rather
+            // than left for the user to hit as errors. Sign-in comes first: the baked
+            // certificate is reused during sign-in, it does not replace it.
+            const _Point(
+              icon: Icons.person_outline,
+              title: 'Sign in once, with the same Apple ID',
+              body: 'Open SideStore inside LiveContainer and sign in with the same '
+                  'Apple ID iPASide uses. iPASide has already baked its certificate in, '
+                  'so SideStore reuses that identity instead of replacing it \u2014 no '
+                  'extra certificate is spent. A different Apple ID makes SideStore mint '
+                  'its own, and a second LiveContainer along with it.',
+            ),
+            const SizedBox(height: Space.s4),
             const _Point(
               icon: Icons.vpn_lock_outlined,
               title: 'It needs a local tunnel',

--- a/tests/test_sidestore_seed.py
+++ b/tests/test_sidestore_seed.py
@@ -1,0 +1,245 @@
+"""Baking iPASide's certificate into the bundled SideStore.
+
+SideStore imports a certificate it finds in its own framework on first launch, which is
+how iPASide can pre-seed it with the same identity that signs LiveContainer - no separate
+Apple ID sign-in, and no way to fork a second LiveContainer under a different account.
+
+The exact shape is a contract with SideStore (and with iLoader's isideload, which writes
+the same files): ALTCertificate.p12 inside SideStoreApp.framework, encrypted with the
+certificate's Apple machineId, plus ALTCertificateID and ALTAppGroups in its Info.plist.
+These tests pin every part of that, hermetically - a throwaway self-signed identity and a
+synthetic bundle, no device, no Apple.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import zipfile
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.oid import NameOID
+
+from ipaside_engine import livecontainer, provision, signing
+
+TEAM = "ASK9QR9SBC"
+SERIAL = "29C8EC73C890EBCA0EE74E017975D97B"
+MACHINE_ID = "1ecfcd29-cce4-40f6-b653-471ecd342381"
+
+
+def _identity() -> tuple[bytes, bytes]:
+    """A throwaway RSA key + self-signed cert, as (key_pem, cert_der)."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "iOS Development: Test")])
+    import datetime
+
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(int(SERIAL, 16))
+        .not_valid_before(datetime.datetime(2026, 1, 1))
+        .not_valid_after(datetime.datetime(2027, 1, 1))
+        .sign(key, hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+    return key_pem, cert.public_bytes(serialization.Encoding.DER)
+
+
+def _sidestore_ipa(path: Path, *, with_framework: bool = True) -> Path:
+    """A minimal LiveContainer+SideStore-shaped IPA."""
+    app = "Payload/LiveContainer.app"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(f"{app}/Info.plist", plistlib.dumps({"CFBundleIdentifier": "com.kdt.livecontainer"}))
+        zf.writestr(f"{app}/LiveContainer", b"\xcf\xfa\xed\xfe main")
+        if with_framework:
+            fw = f"{app}/Frameworks/{livecontainer.SIDESTORE_FRAMEWORK}"
+            zf.writestr(
+                f"{fw}/Info.plist",
+                plistlib.dumps({"CFBundleIdentifier": "com.SideStore.SideStore", "CFBundleName": "SideStore"}),
+            )
+            zf.writestr(f"{fw}/SideStore", b"\xcf\xfa\xed\xfe sidestore")
+    return path
+
+
+@pytest.fixture
+def seeded(monkeypatch, tmp_path):
+    """Run the seeding against the synthetic bundle and return (ipa, framework prefix)."""
+    key_pem, cert_der = _identity()
+    monkeypatch.setattr(provision, "signing_identity", lambda: (key_pem, cert_der, SERIAL))
+    monkeypatch.setattr(provision, "certificate_machine_id", lambda team, serial: MACHINE_ID)
+
+    source = _sidestore_ipa(tmp_path / "LC+SS.ipa")
+    dest = tmp_path / "out"
+    dest.mkdir()
+    result = livecontainer.seed_sidestore_certificate(
+        str(source), {"team_id": TEAM}, str(dest)
+    )
+    fw = f"Payload/LiveContainer.app/Frameworks/{livecontainer.SIDESTORE_FRAMEWORK}"
+    return result, fw
+
+
+# --------------------------------------------------------------------------- #
+# The files SideStore reads
+# --------------------------------------------------------------------------- #
+def test_the_certificate_lands_in_the_sidestore_framework(seeded):
+    result, fw = seeded
+    with zipfile.ZipFile(result) as zf:
+        assert f"{fw}/{livecontainer.ALT_CERTIFICATE_FILE}" in zf.namelist()
+
+
+def test_info_plist_names_the_certificate_and_the_app_group(seeded):
+    result, fw = seeded
+    with zipfile.ZipFile(result) as zf:
+        info = plistlib.loads(zf.read(f"{fw}/Info.plist"))
+    assert info["ALTCertificateID"] == SERIAL
+    assert info["ALTAppGroups"] == [f"group.com.SideStore.SideStore.{TEAM}"]
+    # The framework's own identity must survive - SideStore is still SideStore.
+    assert info["CFBundleIdentifier"] == "com.SideStore.SideStore"
+
+
+def test_the_p12_opens_with_the_machine_id(seeded):
+    result, fw = seeded
+    with zipfile.ZipFile(result) as zf:
+        p12 = zf.read(f"{fw}/{livecontainer.ALT_CERTIFICATE_FILE}")
+
+    key, cert, _ = pkcs12.load_key_and_certificates(p12, MACHINE_ID.encode())
+    assert key is not None and cert is not None
+    assert format(cert.serial_number, "X").upper() == SERIAL
+
+
+def test_the_p12_rejects_any_other_password(seeded):
+    """If the wrong password opened it, the encryption would be theatre."""
+    result, fw = seeded
+    with zipfile.ZipFile(result) as zf:
+        p12 = zf.read(f"{fw}/{livecontainer.ALT_CERTIFICATE_FILE}")
+
+    with pytest.raises(Exception):
+        pkcs12.load_key_and_certificates(p12, b"not-the-machine-id")
+
+
+def test_nothing_else_in_the_bundle_is_disturbed(seeded, tmp_path):
+    """Exactly one file added, none removed - the rest of the app must be untouched."""
+    result, _fw = seeded
+    original = _sidestore_ipa(tmp_path / "orig.ipa")
+
+    def files(p):
+        with zipfile.ZipFile(p) as zf:
+            return {n for n in zf.namelist() if not n.endswith("/")}
+
+    before, after = files(original), files(result)
+    added = after - before
+    assert added == {
+        f"Payload/LiveContainer.app/Frameworks/{livecontainer.SIDESTORE_FRAMEWORK}/"
+        f"{livecontainer.ALT_CERTIFICATE_FILE}"
+    }
+    assert not (before - after), "no original file may be dropped"
+
+
+# --------------------------------------------------------------------------- #
+# When it should not run
+# --------------------------------------------------------------------------- #
+def test_a_build_without_sidestore_is_refused(monkeypatch, tmp_path):
+    key_pem, cert_der = _identity()
+    monkeypatch.setattr(provision, "signing_identity", lambda: (key_pem, cert_der, SERIAL))
+    monkeypatch.setattr(provision, "certificate_machine_id", lambda t, s: MACHINE_ID)
+
+    plain = _sidestore_ipa(tmp_path / "plain.ipa", with_framework=False)
+    dest = tmp_path / "out"
+    dest.mkdir()
+
+    with pytest.raises(livecontainer.LiveContainerError, match="SideStore"):
+        livecontainer.seed_sidestore_certificate(str(plain), {"team_id": TEAM}, str(dest))
+
+
+def test_has_sidestore_detects_the_framework(tmp_path):
+    with_ss = _sidestore_ipa(tmp_path / "with.ipa")
+    without = _sidestore_ipa(tmp_path / "without.ipa", with_framework=False)
+    assert livecontainer.has_sidestore(str(with_ss)) is True
+    assert livecontainer.has_sidestore(str(without)) is False
+
+
+# --------------------------------------------------------------------------- #
+# The sideload pre-sign hook that drives it
+# --------------------------------------------------------------------------- #
+def test_pre_sign_hook_seeds_only_a_sidestore_livecontainer(monkeypatch, tmp_path):
+    from ipaside_engine import sideload
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        livecontainer,
+        "seed_sidestore_certificate",
+        lambda ipa, bundle, dest: calls.append(ipa) or f"{ipa}.seeded",
+    )
+    monkeypatch.setattr(livecontainer, "has_sidestore", lambda path: "withss" in path)
+
+    withss = str(tmp_path / "withss.ipa")
+    plain = str(tmp_path / "plain.ipa")
+    bundle = {"team_id": TEAM}
+
+    assert sideload._profile_pre_sign(
+        livecontainer.SIGNING_PROFILE, withss, bundle, str(tmp_path)
+    ) == f"{withss}.seeded"
+    assert (
+        sideload._profile_pre_sign(livecontainer.SIGNING_PROFILE, plain, bundle, str(tmp_path))
+        is None
+    )
+    # An ordinary sideload never seeds anything.
+    assert (
+        sideload._profile_pre_sign(None, withss, bundle, str(tmp_path)) is None
+    )
+    assert calls == [withss]
+
+
+def test_signing_identity_reads_the_active_account_cache(monkeypatch, tmp_path):
+    """The material comes from the same cache the signing bundle uses."""
+    import base64
+    import json
+
+    key_pem, cert_der = _identity()
+    monkeypatch.setattr(provision.gsa, "load_session", lambda: {"email": "a@b.c"})
+    monkeypatch.setattr(provision, "_account_slug", lambda email: "slug")
+    monkeypatch.setattr(provision.paths, "signing_dir", lambda slug=None: tmp_path)
+    (tmp_path / "certificate.json").write_text(
+        json.dumps(
+            {
+                "serial": SERIAL,
+                "key_pem": base64.b64encode(key_pem).decode(),
+                "cert_der": base64.b64encode(cert_der).decode(),
+            }
+        )
+    )
+
+    got_key, got_cert, got_serial = provision.signing_identity()
+    assert got_serial == SERIAL
+    assert got_key == key_pem
+    assert got_cert == cert_der
+
+
+def test_machine_id_comes_from_apple_by_serial(monkeypatch):
+    monkeypatch.setattr(
+        provision.developer,
+        "list_certificates",
+        lambda team: [
+            {"serialNumber": "OTHER", "machineId": "nope"},
+            {"serialNumber": SERIAL, "machineId": MACHINE_ID},
+        ],
+    )
+    assert provision.certificate_machine_id(TEAM, SERIAL) == MACHINE_ID
+
+
+def test_a_missing_machine_id_is_an_error(monkeypatch):
+    monkeypatch.setattr(
+        provision.developer, "list_certificates", lambda team: [{"serialNumber": SERIAL}]
+    )
+    with pytest.raises(provision.gsa.GsaError, match="machine id"):
+        provision.certificate_machine_id(TEAM, SERIAL)

--- a/tests/test_signin_seed.py
+++ b/tests/test_signin_seed.py
@@ -70,11 +70,11 @@ def test_no_helper_dylib_writes_nothing(monkeypatch, signed_in):
     monkeypatch.setattr(livecontainer.signing, "resolve_helper_dylib", lambda: None)
     wrote: dict = {}
 
-    async def fake_write(*_args, **_kwargs):
+    async def fake_seed(*_args, **_kwargs):
         wrote["called"] = True
-        return []
+        return True
 
-    monkeypatch.setattr(livecontainer, "_write_documents", fake_write)
+    monkeypatch.setattr(livecontainer, "_seed_signin_async", fake_seed)
 
     result = livecontainer.deliver_signin(BUNDLE, "udid")
 
@@ -83,23 +83,26 @@ def test_no_helper_dylib_writes_nothing(monkeypatch, signed_in):
     assert "called" not in wrote, "no request may leave when nothing can consume it"
 
 
-def test_it_is_written_into_livecontainers_documents(monkeypatch, signed_in, has_helper):
+def test_it_delivers_the_request_and_reports_first_launch_suppressed(
+    monkeypatch, signed_in, has_helper
+):
     calls: dict = {}
 
-    async def fake_write(bundle_id, serial, files, *, directories=("/Documents",)):
-        calls.update(
-            bundle_id=bundle_id, serial=serial, files=files, directories=directories
-        )
-        return [f"{d}/{n}" for d in directories for n in files]
+    async def fake_seed(bundle_id, serial, request):
+        calls.update(bundle_id=bundle_id, serial=serial, request=request)
+        return True
 
-    monkeypatch.setattr(livecontainer, "_write_documents", fake_write)
+    monkeypatch.setattr(livecontainer, "_seed_signin_async", fake_seed)
 
     result = livecontainer.deliver_signin(BUNDLE, "udid")
 
-    assert result == {"seeded": True, "automatic": True}
-    assert list(calls["files"]) == [livecontainer.SIGNIN_REQUEST_NAME]
+    assert result == {
+        "seeded": True,
+        "automatic": True,
+        "first_launch_suppressed": True,
+    }
     assert calls["bundle_id"] == BUNDLE["bundle_id"]
-    payload = plistlib.loads(calls["files"][livecontainer.SIGNIN_REQUEST_NAME])
+    payload = plistlib.loads(calls["request"])
     assert payload["AppleIDXcodeToken"] == SESSION["auth_token"]
 
 
@@ -124,9 +127,73 @@ def test_a_delivery_failure_is_reported_not_raised(monkeypatch, signed_in, has_h
     async def explode(*_args, **_kwargs):
         raise OSError("device went away")
 
-    monkeypatch.setattr(livecontainer, "_write_documents", explode)
+    monkeypatch.setattr(livecontainer, "_seed_signin_async", explode)
 
     result = livecontainer.deliver_signin(BUNDLE, "udid")
 
     assert result["seeded"] is False
     assert "device went away" in result["error"]
+
+
+# --------------------------------------------------------------------------- #
+# Surviving SideStore's first-launch keychain reset
+# --------------------------------------------------------------------------- #
+class _FakeAFC:
+    """Just enough of the house_arrest surface for _suppress_first_launch."""
+
+    def __init__(self, existing: bytes | None):
+        self._existing = existing
+        self.written: dict = {}
+        self.made: list = []
+
+    async def get_file_contents(self, path):
+        if self._existing is None:
+            raise FileNotFoundError(path)
+        return self._existing
+
+    async def makedirs(self, path):
+        self.made.append(path)
+
+    async def set_file_contents(self, path, data):
+        self.written[path] = data
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+def test_first_launch_is_written_when_the_prefs_are_absent():
+    """The fresh-install case: no prefs yet, so a value is written to skip the reset."""
+    afc = _FakeAFC(existing=None)
+
+    result = _run(livecontainer._suppress_first_launch(afc))
+
+    assert result is True
+    written = plistlib.loads(afc.written[livecontainer._SIDESTORE_PREFS])
+    assert written[livecontainer._FIRST_LAUNCH_KEY] is not None
+
+
+def test_an_existing_first_launch_date_is_left_untouched():
+    """A store that really has launched keeps its own first-launch date; nothing rewritten."""
+    from datetime import datetime
+
+    existing = plistlib.dumps({livecontainer._FIRST_LAUNCH_KEY: datetime(2020, 1, 1)})
+    afc = _FakeAFC(existing=existing)
+
+    result = _run(livecontainer._suppress_first_launch(afc))
+
+    assert result is True
+    assert afc.written == {}
+
+
+def test_other_prefs_are_preserved_when_setting_first_launch():
+    existing = plistlib.dumps({"someOtherKey": "keepme"})
+    afc = _FakeAFC(existing=existing)
+
+    _run(livecontainer._suppress_first_launch(afc))
+
+    written = plistlib.loads(afc.written[livecontainer._SIDESTORE_PREFS])
+    assert written["someOtherKey"] == "keepme"
+    assert written[livecontainer._FIRST_LAUNCH_KEY] is not None

--- a/tests/test_signin_seed.py
+++ b/tests/test_signin_seed.py
@@ -1,0 +1,132 @@
+"""Signing the built-in SideStore in, with no Apple ID prompt.
+
+SideStore authenticates by token when its keychain already holds an ``adsid`` and the
+``com.apple.gs.xcode.auth`` GrandSlam token - the password-less branch of its
+``AuthenticationOperation.signIn``. iPASide holds both for the account that signed
+LiveContainer, so it seeds them and the built-in store opens already signed in.
+
+The awkward part is delivery. LiveContainer namespaces each guest's keychain into a
+``TEAMID.com.kdt.livecontainer.shared.N`` group where ``N`` is chosen at random per
+container, so the tokens are written into every one of the 128 the host is entitled to -
+which is exactly the list :func:`build_entitlements` signs, and these tests pin the two
+together so they cannot drift.
+"""
+
+from __future__ import annotations
+
+import plistlib
+
+import pytest
+
+from ipaside_engine import gsa, livecontainer
+
+BUNDLE = {"bundle_id": "com.kdt.livecontainer.ABCDE12345", "team_id": "ABCDE12345"}
+SESSION = {"adsid": "0000123-adsid", "auth_token": "xcode-token", "email": "a@b.c"}
+
+
+@pytest.fixture
+def signed_in(monkeypatch):
+    """The active account has the tokens SideStore's token path needs."""
+    monkeypatch.setattr(livecontainer.gsa, "load_session", lambda *a, **k: dict(SESSION))
+
+
+@pytest.fixture
+def has_helper(monkeypatch):
+    """This build ships the dylib that consumes the request on the device."""
+    monkeypatch.setattr(
+        livecontainer.signing,
+        "resolve_helper_dylib",
+        lambda: r"C:\vendor\iPASideCertImport.dylib",
+    )
+
+
+def test_the_request_carries_the_tokens_and_service(signed_in):
+    request = plistlib.loads(livecontainer._signin_request(BUNDLE))
+
+    assert request["AppleIDAdsid"] == SESSION["adsid"]
+    assert request["AppleIDXcodeToken"] == SESSION["auth_token"]
+    assert request["KeychainService"] == livecontainer.SIDESTORE_KEYCHAIN_SERVICE
+
+
+def test_it_targets_every_keychain_group_the_build_is_signed_for(signed_in):
+    """LiveContainer picks one at random, so all of them have to be seeded, and they must
+    be the very groups the app is signed to reach - not a hand-written parallel list."""
+    request = plistlib.loads(livecontainer._signin_request(BUNDLE))
+    expected = livecontainer.build_entitlements(BUNDLE["team_id"], BUNDLE["bundle_id"])[
+        "keychain-access-groups"
+    ]
+
+    assert request["AccessGroups"] == expected
+    assert len(request["AccessGroups"]) == livecontainer.KEYCHAIN_GROUPS
+    assert (
+        request["AccessGroups"][0] == f"{BUNDLE['team_id']}.com.kdt.livecontainer.shared"
+    )
+    assert request["AccessGroups"][-1].endswith(".shared.127")
+
+
+def test_no_helper_dylib_writes_nothing(monkeypatch, signed_in):
+    """Without something on the device to consume it, a live account token must not be
+    dropped into Documents for nothing."""
+    monkeypatch.setattr(livecontainer.signing, "resolve_helper_dylib", lambda: None)
+    wrote: dict = {}
+
+    async def fake_write(*_args, **_kwargs):
+        wrote["called"] = True
+        return []
+
+    monkeypatch.setattr(livecontainer, "_write_documents", fake_write)
+
+    result = livecontainer.deliver_signin(BUNDLE, "udid")
+
+    assert result["seeded"] is False
+    assert result["automatic"] is False
+    assert "called" not in wrote, "no request may leave when nothing can consume it"
+
+
+def test_it_is_written_into_livecontainers_documents(monkeypatch, signed_in, has_helper):
+    calls: dict = {}
+
+    async def fake_write(bundle_id, serial, files, *, directories=("/Documents",)):
+        calls.update(
+            bundle_id=bundle_id, serial=serial, files=files, directories=directories
+        )
+        return [f"{d}/{n}" for d in directories for n in files]
+
+    monkeypatch.setattr(livecontainer, "_write_documents", fake_write)
+
+    result = livecontainer.deliver_signin(BUNDLE, "udid")
+
+    assert result == {"seeded": True, "automatic": True}
+    assert list(calls["files"]) == [livecontainer.SIGNIN_REQUEST_NAME]
+    assert calls["bundle_id"] == BUNDLE["bundle_id"]
+    payload = plistlib.loads(calls["files"][livecontainer.SIGNIN_REQUEST_NAME])
+    assert payload["AppleIDXcodeToken"] == SESSION["auth_token"]
+
+
+def test_not_signed_in_is_reported_not_raised(monkeypatch, has_helper):
+    """The tokens come from a signed-in account; without one, say so rather than crash the
+    install that has already put LiveContainer on the phone."""
+
+    def no_session(*_args, **_kwargs):
+        raise gsa.GsaError("not signed in")
+
+    monkeypatch.setattr(livecontainer.gsa, "load_session", no_session)
+
+    result = livecontainer.deliver_signin(BUNDLE, "udid")
+
+    assert result["seeded"] is False
+    assert "not signed in" in result["error"]
+
+
+def test_a_delivery_failure_is_reported_not_raised(monkeypatch, signed_in, has_helper):
+    """LiveContainer is already installed by then; only the hand-off failed."""
+
+    async def explode(*_args, **_kwargs):
+        raise OSError("device went away")
+
+    monkeypatch.setattr(livecontainer, "_write_documents", explode)
+
+    result = livecontainer.deliver_signin(BUNDLE, "udid")
+
+    assert result["seeded"] is False
+    assert "device went away" in result["error"]

--- a/tools/lc-cert-import/build.sh
+++ b/tools/lc-cert-import/build.sh
@@ -32,6 +32,7 @@ xcrun --sdk iphoneos clang \
     -dynamiclib \
     -fobjc-arc \
     -framework Foundation \
+    -framework Security \
     -install_name "@executable_path/iPASideCertImport.dylib" \
     -Wall -Wextra -Werror \
     -O2 \

--- a/tools/lc-cert-import/iPASideCertImport.m
+++ b/tools/lc-cert-import/iPASideCertImport.m
@@ -204,20 +204,23 @@ static void iPASideSeedCertificate(NSString *documents) {
  * refresh replaces a rotated token rather than colliding. Returns YES on a stored item.
  */
 static BOOL iPASideKeychainSet(NSString *service, NSString *account, NSString *accessGroup,
-                               NSString *value) {
+                               BOOL synchronizable, NSString *value) {
     NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
     if (data == nil) {
         return NO;
     }
 
-    /* A nil access group means "the process default" - which is where the bundled
-     * SideStore reads, since LiveContainer does not hook its keychain (see the caller).
-     * Passing nil for kSecAttrAccessGroup is not allowed, so the key is simply omitted. */
+    id syncValue = synchronizable ? (__bridge id)kCFBooleanTrue : (__bridge id)kCFBooleanFalse;
+
+    /* Delete only the matching synchronizable variant, so writing a synchronizable and a
+     * non-synchronizable copy of the same key leaves both in place - they are distinct
+     * keychain items. A nil access group means the process default (passing nil for
+     * kSecAttrAccessGroup is not allowed, so the key is simply omitted). */
     NSMutableDictionary *identity = [@{
         (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
         (__bridge id)kSecAttrService: service,
         (__bridge id)kSecAttrAccount: account,
-        (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
+        (__bridge id)kSecAttrSynchronizable: syncValue,
     } mutableCopy];
     if (accessGroup != nil) {
         identity[(__bridge id)kSecAttrAccessGroup] = accessGroup;
@@ -229,13 +232,45 @@ static BOOL iPASideKeychainSet(NSString *service, NSString *account, NSString *a
         (__bridge id)kSecAttrService: service,
         (__bridge id)kSecAttrAccount: account,
         (__bridge id)kSecAttrAccessible: (__bridge id)kSecAttrAccessibleAfterFirstUnlock,
-        (__bridge id)kSecAttrSynchronizable: (__bridge id)kCFBooleanTrue,
+        (__bridge id)kSecAttrSynchronizable: syncValue,
         (__bridge id)kSecValueData: data,
     } mutableCopy];
     if (accessGroup != nil) {
         item[(__bridge id)kSecAttrAccessGroup] = accessGroup;
     }
     return SecItemAdd((__bridge CFDictionaryRef)item, NULL) == errSecSuccess;
+}
+
+/**
+ * Read one key back exactly the way SideStore's KeychainAccess does - service + account,
+ * no access group, returning attributes - across the three synchronizable modes, and log
+ * which access group each match lands in. This is the truest test of what SideStore's own
+ * read will see, because it runs unhooked in the same process. Values are never logged.
+ */
+static void iPASideKeychainDiagnose(NSString *service, NSString *account) {
+    CFTypeRef syncModes[3] = {kSecAttrSynchronizableAny, kCFBooleanTrue, kCFBooleanFalse};
+    const char *syncLabels[3] = {"any", "true", "false"};
+    for (int i = 0; i < 3; i++) {
+        NSDictionary *query = @{
+            (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+            (__bridge id)kSecAttrService: service,
+            (__bridge id)kSecAttrAccount: account,
+            (__bridge id)kSecAttrSynchronizable: (__bridge id)syncModes[i],
+            (__bridge id)kSecReturnAttributes: (__bridge id)kCFBooleanTrue,
+            (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne,
+        };
+        CFTypeRef result = NULL;
+        OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+        if (status == errSecSuccess && result != NULL) {
+            NSDictionary *attrs = (__bridge NSDictionary *)result;
+            iPASideLog(@"readback %@ sync=%s: FOUND in group=%@", account, syncLabels[i],
+                       attrs[(__bridge id)kSecAttrAccessGroup]);
+            CFRelease(result);
+        } else {
+            iPASideLog(@"readback %@ sync=%s: not found (status %d)", account, syncLabels[i],
+                       (int)status);
+        }
+    }
 }
 
 /**
@@ -275,8 +310,8 @@ static void iPASideSeedSignIn(NSString *documents) {
         if (![group isKindOfClass:NSString.class] || ((NSString *)group).length == 0) {
             continue;
         }
-        BOOL wroteAdsid = iPASideKeychainSet(service, kSideStoreAdsidAccount, group, adsid);
-        BOOL wroteToken = iPASideKeychainSet(service, kSideStoreXcodeTokenAccount, group, token);
+        BOOL wroteAdsid = iPASideKeychainSet(service, kSideStoreAdsidAccount, group, YES, adsid);
+        BOOL wroteToken = iPASideKeychainSet(service, kSideStoreXcodeTokenAccount, group, YES, token);
         if (wroteAdsid && wroteToken) {
             stored++;
         }
@@ -286,9 +321,14 @@ static void iPASideSeedSignIn(NSString *documents) {
      * keychain hook for SideStore (the isSideStore guard in LCBootstrap), so SideStore is
      * unhooked and reads the process *default* access group, not a namespaced one. This
      * dylib is unhooked too, so a write with no access group lands in that same default
-     * group. The 128 explicit groups above are kept only as a fallback for a hooked build. */
-    BOOL defaultOk = iPASideKeychainSet(service, kSideStoreAdsidAccount, nil, adsid) &&
-                     iPASideKeychainSet(service, kSideStoreXcodeTokenAccount, nil, token);
+     * group. Written in both synchronizable variants, since SideStore's KeychainAccess get
+     * may query either - whichever it uses, one matches. The 128 explicit groups above are
+     * a fallback for a hooked build. */
+    BOOL d1 = iPASideKeychainSet(service, kSideStoreAdsidAccount, nil, YES, adsid);
+    BOOL d2 = iPASideKeychainSet(service, kSideStoreXcodeTokenAccount, nil, YES, token);
+    BOOL d3 = iPASideKeychainSet(service, kSideStoreAdsidAccount, nil, NO, adsid);
+    BOOL d4 = iPASideKeychainSet(service, kSideStoreXcodeTokenAccount, nil, NO, token);
+    BOOL defaultOk = d1 && d2 && d3 && d4;
 
     if (stored == 0 && !defaultOk) {
         iPASideLog(@"could not store sign-in tokens (0/%lu groups, default failed); "
@@ -299,7 +339,10 @@ static void iPASideSeedSignIn(NSString *documents) {
 
     iPASideLog(@"seeded sign-in tokens: %lu of %lu groups, default group %@",
                (unsigned long)stored, (unsigned long)((NSArray *)groups).count,
-               defaultOk ? @"ok" : @"FAILED");
+               defaultOk ? @"ok" : @"partial");
+
+    /* Log exactly what SideStore's own read will see - unhooked, same process. */
+    iPASideKeychainDiagnose(service, kSideStoreAdsidAccount);
 
     NSError *error = nil;
     if (![NSFileManager.defaultManager removeItemAtPath:path error:&error]) {

--- a/tools/lc-cert-import/iPASideCertImport.m
+++ b/tools/lc-cert-import/iPASideCertImport.m
@@ -26,6 +26,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Security/Security.h>
 
 /* Written by iPASide over house_arrest; deleted by us once the import is verified. */
 static NSString *const kRequestFileName = @"iPASide-cert-import.plist";
@@ -40,6 +41,33 @@ static NSString *const kLCCertificateData = @"LCCertificateData";
 static NSString *const kLCCertificatePassword = @"LCCertificatePassword";
 static NSString *const kLCCertificateUpdateDate = @"LCCertificateUpdateDate";
 static NSString *const kLCAppGroupID = @"LCAppGroupID";
+
+/*
+ * Sign-in seeding: the second thing this dylib does.
+ *
+ * The +SideStore build carries SideStore, which refreshes apps on the device. SideStore
+ * authenticates by token when its keychain already holds an "adsid" and the Xcode
+ * GrandSlam token - the password-less branch of AuthenticationOperation.signIn. iPASide
+ * already has both for the account that signed LiveContainer, so seeding them means the
+ * built-in store is signed in the moment it opens, with no Apple ID prompt.
+ *
+ * The catch is where they go. LiveContainer hooks every keychain call a *guest* makes and
+ * forces it into a per-guest access group `TEAMID.com.kdt.livecontainer.shared.N`, where N
+ * is assigned at random when the guest's container is created. That hook is installed at
+ * guest launch, not here: this dylib runs in the LiveContainer host before any guest, so
+ * our own SecItemAdd is unhooked and the access group we name is the one the item lands in.
+ * The host is entitled to all 128 of those groups, so we write into every one of them -
+ * whichever N SideStore's guest is later assigned, its read finds the tokens waiting.
+ */
+static NSString *const kSignInFileName = @"iPASide-signin.plist";
+static NSString *const kSignInAdsid = @"AppleIDAdsid";
+static NSString *const kSignInXcodeToken = @"AppleIDXcodeToken";
+static NSString *const kSignInKeychainService = @"KeychainService";
+static NSString *const kSignInAccessGroups = @"AccessGroups";
+
+/* SideStore's KeychainAccess account names - its API, not ours. */
+static NSString *const kSideStoreAdsidAccount = @"appleIDAdsid";
+static NSString *const kSideStoreXcodeTokenAccount = @"appleIDXcodeToken";
 
 static void iPASideLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
 
@@ -111,13 +139,7 @@ static void iPASideConsumeRequest(NSString *requestPath) {
     }
 }
 
-__attribute__((constructor))
-static void iPASideSeedCertificate(void) {
-    NSString *documents = iPASideDocumentsPath();
-    if (documents.length == 0) {
-        return;
-    }
-
+static void iPASideSeedCertificate(NSString *documents) {
     NSString *requestPath = [documents stringByAppendingPathComponent:kRequestFileName];
     NSDictionary *request = iPASideReadRequest(requestPath);
     if (request == nil) {
@@ -171,4 +193,114 @@ static void iPASideSeedCertificate(void) {
     iPASideLog(@"imported %lu bytes into %@",
                (unsigned long)certificateData.length, groupID);
     iPASideConsumeRequest(requestPath);
+}
+
+/**
+ * Store one string where SideStore's KeychainAccess reads it: a generic-password item
+ * keyed by service + account, afterFirstUnlock, synchronizable - the exact attributes
+ * `Keychain(service:).accessibility(.afterFirstUnlock).synchronizable(true)` queries with.
+ * The access group is named explicitly, since the guest keychain hook that would supply
+ * it is not installed in the host where this runs. Any existing copy is removed first so a
+ * refresh replaces a rotated token rather than colliding. Returns YES on a stored item.
+ */
+static BOOL iPASideKeychainSet(NSString *service, NSString *account, NSString *accessGroup,
+                               NSString *value) {
+    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
+    if (data == nil) {
+        return NO;
+    }
+
+    NSDictionary *identity = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: service,
+        (__bridge id)kSecAttrAccount: account,
+        (__bridge id)kSecAttrAccessGroup: accessGroup,
+        (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
+    };
+    SecItemDelete((__bridge CFDictionaryRef)identity);
+
+    NSDictionary *item = @{
+        (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: service,
+        (__bridge id)kSecAttrAccount: account,
+        (__bridge id)kSecAttrAccessGroup: accessGroup,
+        (__bridge id)kSecAttrAccessible: (__bridge id)kSecAttrAccessibleAfterFirstUnlock,
+        (__bridge id)kSecAttrSynchronizable: (__bridge id)kCFBooleanTrue,
+        (__bridge id)kSecValueData: data,
+    };
+    return SecItemAdd((__bridge CFDictionaryRef)item, NULL) == errSecSuccess;
+}
+
+/**
+ * Seed the built-in SideStore's sign-in tokens into every LiveContainer keychain group.
+ *
+ * Values are never logged: the request carries a live account token, and the point of
+ * consuming the file is that the token does not linger on disk. A request that stores
+ * nowhere is left in place to be inspected rather than silently dropped.
+ */
+static void iPASideSeedSignIn(NSString *documents) {
+    NSString *path = [documents stringByAppendingPathComponent:kSignInFileName];
+    if (![NSFileManager.defaultManager fileExistsAtPath:path]) {
+        return;
+    }
+
+    NSDictionary *request = [NSDictionary dictionaryWithContentsOfFile:path];
+    if (![request isKindOfClass:NSDictionary.class]) {
+        iPASideLog(@"sign-in request at %@ is not a dictionary; ignoring", path);
+        return;
+    }
+
+    id adsid = request[kSignInAdsid];
+    id token = request[kSignInXcodeToken];
+    id service = request[kSignInKeychainService];
+    id groups = request[kSignInAccessGroups];
+
+    if (![adsid isKindOfClass:NSString.class] || ((NSString *)adsid).length == 0 ||
+        ![token isKindOfClass:NSString.class] || ((NSString *)token).length == 0 ||
+        ![service isKindOfClass:NSString.class] || ((NSString *)service).length == 0 ||
+        ![groups isKindOfClass:NSArray.class] || ((NSArray *)groups).count == 0) {
+        iPASideLog(@"sign-in request is missing a usable field; leaving it for inspection");
+        return;
+    }
+
+    NSUInteger stored = 0;
+    for (id group in (NSArray *)groups) {
+        if (![group isKindOfClass:NSString.class] || ((NSString *)group).length == 0) {
+            continue;
+        }
+        BOOL wroteAdsid = iPASideKeychainSet(service, kSideStoreAdsidAccount, group, adsid);
+        BOOL wroteToken = iPASideKeychainSet(service, kSideStoreXcodeTokenAccount, group, token);
+        if (wroteAdsid && wroteToken) {
+            stored++;
+        }
+    }
+
+    if (stored == 0) {
+        iPASideLog(@"could not store sign-in tokens in any of %lu groups; leaving the request",
+                   (unsigned long)((NSArray *)groups).count);
+        return;
+    }
+
+    iPASideLog(@"seeded sign-in tokens into %lu of %lu keychain groups",
+               (unsigned long)stored, (unsigned long)((NSArray *)groups).count);
+
+    NSError *error = nil;
+    if (![NSFileManager.defaultManager removeItemAtPath:path error:&error]) {
+        iPASideLog(@"could not remove the sign-in request: %@", error.localizedDescription);
+    }
+}
+
+/**
+ * Both seeds run once, before LiveContainer's main(). Either request may be absent - a
+ * plain build with no SideStore never delivers a sign-in request, and a repeat install
+ * finds nothing left to do - so each is independently a no-op when its file is not there.
+ */
+__attribute__((constructor))
+static void iPASideSeed(void) {
+    NSString *documents = iPASideDocumentsPath();
+    if (documents.length == 0) {
+        return;
+    }
+    iPASideSeedCertificate(documents);
+    iPASideSeedSignIn(documents);
 }

--- a/tools/lc-cert-import/iPASideCertImport.m
+++ b/tools/lc-cert-import/iPASideCertImport.m
@@ -210,24 +210,31 @@ static BOOL iPASideKeychainSet(NSString *service, NSString *account, NSString *a
         return NO;
     }
 
-    NSDictionary *identity = @{
+    /* A nil access group means "the process default" - which is where the bundled
+     * SideStore reads, since LiveContainer does not hook its keychain (see the caller).
+     * Passing nil for kSecAttrAccessGroup is not allowed, so the key is simply omitted. */
+    NSMutableDictionary *identity = [@{
         (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
         (__bridge id)kSecAttrService: service,
         (__bridge id)kSecAttrAccount: account,
-        (__bridge id)kSecAttrAccessGroup: accessGroup,
         (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
-    };
+    } mutableCopy];
+    if (accessGroup != nil) {
+        identity[(__bridge id)kSecAttrAccessGroup] = accessGroup;
+    }
     SecItemDelete((__bridge CFDictionaryRef)identity);
 
-    NSDictionary *item = @{
+    NSMutableDictionary *item = [@{
         (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
         (__bridge id)kSecAttrService: service,
         (__bridge id)kSecAttrAccount: account,
-        (__bridge id)kSecAttrAccessGroup: accessGroup,
         (__bridge id)kSecAttrAccessible: (__bridge id)kSecAttrAccessibleAfterFirstUnlock,
         (__bridge id)kSecAttrSynchronizable: (__bridge id)kCFBooleanTrue,
         (__bridge id)kSecValueData: data,
-    };
+    } mutableCopy];
+    if (accessGroup != nil) {
+        item[(__bridge id)kSecAttrAccessGroup] = accessGroup;
+    }
     return SecItemAdd((__bridge CFDictionaryRef)item, NULL) == errSecSuccess;
 }
 
@@ -275,14 +282,24 @@ static void iPASideSeedSignIn(NSString *documents) {
         }
     }
 
-    if (stored == 0) {
-        iPASideLog(@"could not store sign-in tokens in any of %lu groups; leaving the request",
+    /* The write that actually signs the bundled SideStore in. LiveContainer skips its
+     * keychain hook for SideStore (the isSideStore guard in LCBootstrap), so SideStore is
+     * unhooked and reads the process *default* access group, not a namespaced one. This
+     * dylib is unhooked too, so a write with no access group lands in that same default
+     * group. The 128 explicit groups above are kept only as a fallback for a hooked build. */
+    BOOL defaultOk = iPASideKeychainSet(service, kSideStoreAdsidAccount, nil, adsid) &&
+                     iPASideKeychainSet(service, kSideStoreXcodeTokenAccount, nil, token);
+
+    if (stored == 0 && !defaultOk) {
+        iPASideLog(@"could not store sign-in tokens (0/%lu groups, default failed); "
+                   @"leaving the request",
                    (unsigned long)((NSArray *)groups).count);
         return;
     }
 
-    iPASideLog(@"seeded sign-in tokens into %lu of %lu keychain groups",
-               (unsigned long)stored, (unsigned long)((NSArray *)groups).count);
+    iPASideLog(@"seeded sign-in tokens: %lu of %lu groups, default group %@",
+               (unsigned long)stored, (unsigned long)((NSArray *)groups).count,
+               defaultOk ? @"ok" : @"FAILED");
 
     NSError *error = nil;
     if (![NSFileManager.defaultManager removeItemAtPath:path error:&error]) {


### PR DESCRIPTION
## What

The `+SideStore` LiveContainer build now opens **already signed in** as the same Apple ID iPASide uses — no Apple ID prompt inside SideStore — so on-device refresh is truly zero-touch.

## Why it works

SideStore's `AuthenticationOperation.signIn` has a password-less branch, `authenticateWithToken(adsid:xcodeToken:)`, taken whenever its keychain holds `appleIDAdsid` + `appleIDXcodeToken`. Those are `session.dsid` and `session.authToken` — which iPASide already holds for the signed-in account as `adsid` and the `com.apple.gs.xcode.auth` GrandSlam token. Apple dates that token ~1 year out, so a single seed outlasts every 7-day app expiry in between.

## The delivery problem, and the fix

LiveContainer hooks every **guest** `SecItem` call and forces it into a per-guest access group `TEAMID.com.kdt.livecontainer.shared.N`, where `N` is `Int.random(0..<128)` per container. So a keychain write can't target SideStore's group by name.

The injected helper dylib runs in the **host**, before any guest — so that hook isn't installed yet — and the host is entitled to all 128 groups. It writes the two items into **every** group (exactly the `build_entitlements` keychain list), so whichever `N` SideStore's guest is later assigned, its read finds them.

## Changes

- `livecontainer.py`: `_signin_request()` + `deliver_signin()`. Skips entirely if the build ships no helper dylib (a live token is never dropped with nothing to consume it); never raises.
- `sideload.py`: delivered from the post-install hook next to the pairing file, so it's re-seeded on every refresh (rotated token / re-paired device).
- `iPASideCertImport.m`: seeds the two items with SideStore's exact attributes (`com.SideStore.SideStore`, `afterFirstUnlock`, `synchronizable`), never logs values, deletes the request once stored. `build.sh` links `Security.framework`.
- `tests/test_signin_seed.py` (6): request targets exactly the signed groups, no-dylib writes nothing, failures reported not raised.
- Docs correction: the earlier certificate bake was overstated as removing sign-in. It doesn't — it makes SideStore *reuse* iPASide's certificate instead of revoking it. The LiveContainer tab, README and CHANGELOG now state the one-time sign-in, which remains the fallback if the seed is absent.

## Verification

- Full engine suite green (346), including the 6 new tests.
- **Pending:** the dylib is iOS arm64 and is built by this PR's macOS CI (`build-lc-helper.yml`); its artifact is vendored in a follow-up commit. On-device proof (SideStore opens signed in) is the final gate before release.

## Security note

The seed places a live ~1-year account token (free dev Apple ID) into a request file on the device until the dylib imports it and deletes it. Never logged.
