### PR TITLE
1.1.2: sign IPAs >2 GB, recover a broken anisette cache

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# The zsign build runs in MSYS2 bash and applies the patch with `git apply`;
+# both must stay LF regardless of the cloning machine's core.autocrlf, or the
+# build breaks on a fresh Windows clone. Scoped to these two files so nothing
+# else is renormalised.
+/tools/zsign/build-zsign.sh text eol=lf
+/tools/zsign/win-largefile.patch text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to iPASide are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and
 [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.1.2] - 2026-07-29
+
+### Fixed
+
+- **Signing an IPA larger than about 2 GB failed immediately with "Unzip failed!".** The
+  bundled signer (zsign) reads IPAs through a copy of minizip that, on Windows, falls back
+  to 32-bit file offsets, so it could not seek past the 2 GB mark to reach the ZIP index of
+  a large app - a 4 GB game's IPA never got past unzipping, no matter how many times you
+  tried. Both reading and writing the archive now go through the 64-bit Windows file API
+  (iowin32), and the fix is proven by signing a real 4.19 GB IPA end to end: unzip, sign all
+  53 frameworks and the app, and repack to a valid 4.19 GB output. Anything under 2 GB was
+  never affected, which is why most apps signed fine.
+
+- **Signing in could break permanently with a cryptic archive error.** iPASide sets up Apple
+  sign-in using a small set of device libraries it downloads once from a public host and
+  caches together with the provisioning state. If that download was intercepted (a proxy or
+  captive-portal page arriving in place of the archive) or the cache was left half-written by
+  an interrupted first run, every later attempt re-threw a raw "not a gzip/bzip2/xz/tar file"
+  error from deep in the archive parser - and the only way out was to find and delete the
+  cache file by hand. Now a cache that will not load is discarded and rebuilt automatically,
+  the download is verified to be a real archive before it is used (and retried if not), and a
+  genuine failure reports that the provisioning server may be down or the network is blocking
+  it, instead of a parser stack trace. The libraries are still downloaded, not bundled, so
+  nothing of Apple's is redistributed.
+
 ## [1.1.1] - 2026-07-28
 
 ### Fixed

--- a/src/iPASide.Engine/ipaside_engine/__init__.py
+++ b/src/iPASide.Engine/ipaside_engine/__init__.py
@@ -11,4 +11,4 @@ This package is intentionally usable stand-alone as a CLI:
     python -m ipaside_engine devices
 """
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/src/iPASide.Engine/ipaside_engine/anisette.py
+++ b/src/iPASide.Engine/ipaside_engine/anisette.py
@@ -1,35 +1,101 @@
 """Anisette provider.
 
-Anisette headers are the device-provisioning data Apple's GrandSlam (GSA)
-servers require to authenticate an Apple ID from a non-Apple machine. iPASide
-generates them fully in-process using the pure-Python ``anisette`` package,
-which runs Apple's own portable provisioning libraries (downloaded once, ~3MB,
-then cached). No account information is contained in anisette data, and nothing
-is sent to any third-party server.
+Anisette headers are the device-provisioning data Apple's GrandSlam (GSA) servers
+require to authenticate an Apple ID from a non-Apple machine. iPASide generates them
+fully in-process using the pure-Python ``anisette`` package, which runs Apple's own
+portable provisioning libraries.
 
-The combined library bundle + provisioning state is persisted to a single cache
-file so the machine presents as a stable, already-provisioned device on every
-run - re-provisioning repeatedly is what trips Apple's anti-abuse checks.
+Those libraries (about 2 MB, arm64, which the provider emulates regardless of host CPU)
+are fetched once from a public host and then cached with the provisioning state in a
+single file, so the machine presents as a stable, already-provisioned device on every
+run - re-provisioning repeatedly is what trips Apple's anti-abuse checks. The libraries
+are Apple's own binaries, so iPASide downloads them rather than redistributing them, but
+it does the download itself: it retries, checks the response really is an archive, and
+raises a message a user can act on instead of dying on a raw archive-parser error. No
+Apple ID information is in anisette data, and none is sent to the library host.
 """
 
 from __future__ import annotations
 
+import io
 from importlib import metadata
 from typing import Any
 
+import requests
+
 from . import paths
+from .errors import EngineError
+
+
+class AnisetteError(EngineError):
+    """Device provisioning could not be set up (libraries unreachable, or state broken)."""
+
+
+#: Where the provisioning libraries are fetched from, tried in order. A second, licensing-
+#: clean mirror can be appended here; iPASide will not host them itself, as that would be
+#: the redistribution the download exists to avoid.
+_LIBS_URLS: tuple[str, ...] = (
+    "https://anisette.dl.mikealmel.ooo/libs?arch=arm64-v8a",
+)
+
+#: The formats the anisette package can read the bundle as. A response that starts with
+#: none of these is an error page or a truncated download, not the libraries - caught here
+#: so it fails with a clear message rather than a cryptic "not a gzip/tar file" much later.
+_ARCHIVE_MAGIC = (b"PK", b"\x1f\x8b", b"BZh", b"\xfd7zXZ")
+
+
+def _download_libs() -> io.BytesIO:
+    """Fetch Apple's provisioning libraries, trying each source with retries.
+
+    Raises :class:`AnisetteError` - not the archive parser's error - when nothing usable
+    comes back, so the app can say the server is down or the network is blocking it.
+    """
+    attempts: list[str] = []
+    for url in _LIBS_URLS:
+        for _ in range(3):
+            try:
+                response = requests.get(url, timeout=30)
+                response.raise_for_status()
+                data = response.content
+                if not any(data.startswith(magic) for magic in _ARCHIVE_MAGIC):
+                    raise ValueError(
+                        f"response was not an archive (starts {data[:12]!r})"
+                    )
+                return io.BytesIO(data)
+            except Exception as exc:  # noqa: BLE001 - record every source that failed
+                attempts.append(f"{url}: {exc}")
+    raise AnisetteError(
+        "Could not download Apple's device-provisioning libraries. The provisioning "
+        "server may be down, or your network is blocking it - check your connection and "
+        "try again.\n\nTried:\n  " + "\n  ".join(attempts)
+    )
 
 
 def _load_provider() -> Any:
-    """Return a ready, provisioned Anisette provider, persisting its state."""
+    """Return a ready, provisioned Anisette provider, persisting its state.
+
+    A cache that cannot be loaded is discarded and rebuilt rather than re-raised: an
+    interrupted first provision, or a first run that saved a bad download, would otherwise
+    throw the same archive error on every later launch with no way out but finding and
+    deleting the file by hand.
+    """
     from anisette import Anisette
 
     state = paths.anisette_state_file()
+
+    def _fresh() -> Any:
+        return Anisette.init(_download_libs())
+
     if state.exists():
-        provider = Anisette.load(str(state))
+        try:
+            provider = Anisette.load(str(state))
+        except AnisetteError:
+            raise
+        except Exception:  # noqa: BLE001 - any load failure means the cache is unusable
+            state.unlink(missing_ok=True)
+            provider = _fresh()
     else:
-        # First use downloads Apple's portable provisioning libraries.
-        provider = Anisette.init()
+        provider = _fresh()
 
     if not provider.is_provisioned:
         provider.provision()

--- a/src/iPASide.Flutter/lib/app_version.dart
+++ b/src/iPASide.Flutter/lib/app_version.dart
@@ -4,4 +4,4 @@
 /// in a plugin, so it is mirrored here and `test/app_version_test.dart` fails the
 /// build if the two ever drift — a stale value would make the updater compare
 /// against the wrong version and either nag forever or never offer an update.
-const String kAppVersion = '1.1.1';
+const String kAppVersion = '1.1.2';

--- a/src/iPASide.Flutter/pubspec.yaml
+++ b/src/iPASide.Flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.1+2
+version: 1.1.2+3
 
 environment:
   sdk: ^3.12.2

--- a/tools/zsign/build-zsign.sh
+++ b/tools/zsign/build-zsign.sh
@@ -35,6 +35,14 @@ cd "$WORK"
 echo "== patching certcheck.cpp (ssize_t guard for MinGW) =="
 sed -i 's/^typedef int ssize_t;/#ifdef _MSC_VER\ntypedef int ssize_t;\n#endif/' src/certcheck.cpp
 
+# Windows minizip defaults to 32-bit fseek (USE_FILE32API in ioapi.h), so zsign cannot
+# seek to the central directory of an IPA larger than ~2GB - large games (e.g. a 4GB PUBG
+# IPA) fail immediately with "Unzip failed!". Route archive read/write through iowin32's
+# 64-bit Win32 file API instead. Fails loudly if upstream drifts, rather than silently
+# reverting to the 32-bit path.
+echo "== patching archive.cpp (64-bit file I/O for >2GB IPAs) =="
+git apply "$HERE/win-largefile.patch"
+
 echo "== compiling =="
 WIN=build/windows/vs2022/zsign/src
 OBJ=.obj
@@ -51,7 +59,7 @@ done
 
 # C++ sources. MSVC pulls in libc headers transitively; GCC needs them forced.
 for f in src/*.cpp src/common/*.cpp "$WIN/getopt.cpp" "$WIN/iconv.cpp"; do
-  g++ -std=c++11 -O3 -include cstdint -include cstring -include cstdio -include cstdlib \
+  g++ -std=c++11 -O3 -DZSIGN_VERSION=iPASide -include cstdint -include cstring -include cstdio -include cstdlib \
       -Wno-unused-result -Wno-deprecated-declarations $INC -c "$f" -o "$OBJ/$(echo "$f" | tr '/' '_').o"
 done
 

--- a/tools/zsign/win-largefile.patch
+++ b/tools/zsign/win-largefile.patch
@@ -1,0 +1,46 @@
+diff --git a/src/common/archive.cpp b/src/common/archive.cpp
+index 78c49b1..35ede15 100644
+--- a/src/common/archive.cpp
++++ b/src/common/archive.cpp
+@@ -9,6 +9,9 @@
+ #else
+ #include "third-party/minizip/zip.h"
+ #include "third-party/minizip/unzip.h"
++#ifdef _WIN32
++#include "third-party/minizip/iowin32.h"
++#endif
+ #endif
+ 
+ void Zip::GetModificationTime(const char* path, void* zfi)
+@@ -91,7 +94,15 @@ bool Zip::Archive(const string& strFolder, const string& strZipFile, int nZipLev
+         return false;
+     }
+     
++#ifdef _WIN32
++    // Windows minizip defaults to 32-bit fseek (USE_FILE32API), which cannot address the
++    // central directory of a >2GB output IPA; iowin32 uses 64-bit Win32 file APIs.
++    zlib_filefunc64_def zffunc;
++    fill_win32_filefunc64A(&zffunc);
++    zipFile zf = zipOpen2_64(strZipFile.c_str(), 0, NULL, &zffunc);
++#else
+     zipFile zf = zipOpen64(strZipFile.c_str(), 0);
++#endif
+     if (!zf) {
+ 		ZLog::ErrorV(">>> Zip: Failed to create zip file: %s\n", strZipFile.c_str());
+         return false;
+@@ -128,7 +139,15 @@ bool Zip::Archive(const string& strFolder, const string& strZipFile, int nZipLev
+ 
+ bool Zip::_EnumZipItems(const char* zip_file, enum_zip_items_callback callback)
+ {
++#ifdef _WIN32
++	// See note in Zip::Archive: 32-bit fseek cannot reach the central directory of a
++	// >2GB IPA (e.g. large games), so opening it fails outright. iowin32 is 64-bit.
++	zlib_filefunc64_def uffunc;
++	fill_win32_filefunc64A(&uffunc);
++	unzFile uf = unzOpen2_64(zip_file, &uffunc);
++#else
+ 	unzFile uf = unzOpen64(zip_file);
++#endif
+ 	if (NULL == uf) {
+ 		return false;
+ 	}


### PR DESCRIPTION
## What

Two hardware-reported bugs, shipped as **1.1.2**.

### `fix(zsign)` — signing IPAs larger than ~2 GB
zsign's vendored minizip uses 32-bit file offsets on Windows (`USE_FILE32API`), so it
could not seek to the central directory of an archive over 2 GB — a 4 GB game's IPA
failed instantly with "Unzip failed!". Both the read (`unzOpen2_64`) and write
(`zipOpen2_64`) now go through iowin32's 64-bit Win32 file API, patched into the upstream
clone during the build (`tools/zsign/win-largefile.patch`, applied by `git apply`, fails
loudly if upstream drifts). `-DZSIGN_VERSION=iPASide` restored. The script and patch are
pinned to LF so a fresh clone with `autocrlf=true` can't break the build.

### `fix(anisette)` — recovering a broken provisioning cache
A blocked download (a proxy/error page instead of the archive) or a half-written cache
from an interrupted first run made every later launch re-throw a raw `tarfile` parser
error, unrecoverable without deleting a file by hand. iPASide now discards an unloadable
cache and re-provisions, verifies the download really is an archive (retrying if not), and
reports a clear "provisioning server may be down or the network is blocking it". The
libraries are still downloaded, not bundled — nothing of Apple's is redistributed.

## Verified
- Engine test suite green.
- Built engine + app + installer as 1.1.2, installed the real installer, and drove the
  **installed** engine through a full sideload of a real 4.19 GB IPA onto a physical
  iPhone: provision → sign → install, 0→100%, app on device. The step that used to die at
  "Unzip failed!" now completes.
