### PR TITLE
1.1.3: fix Apple ID sign-in on non-English Windows (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to iPASide are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and
 [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.1.3] - 2026-07-31
+
+### Fixed
+
+- **Signing in to an Apple ID failed on non-English Windows with a cryptic
+  ``latin-1`` error.** After the password check succeeded, the trusted-device 2FA
+  step puts anisette fields on the HTTP request. The upstream anisette package
+  fills ``X-Apple-I-TimeZone`` from the OS timezone *display name*, which on a
+  Chinese install is ``中国标准时间`` (and similarly localized on other languages).
+  HTTP headers are latin-1, so urllib3 raised
+  ``'latin-1' codec can't encode characters in position 0-5`` and sign-in never
+  reached the code prompt ([#3](https://github.com/pwnapplehat/iPASide/issues/3)).
+  Timezone and locale are now rewritten to ASCII Apple-style values (abbreviation
+  or ``GMT±HH:MM``, and an ASCII locale tag) at the single place every caller gets
+  anisette headers, so GrandSlam 2FA and developer services stay wire-safe. Nine
+  regression tests reproduce the exact encode failure and pin the sanitiser.
+
 ## [1.1.2] - 2026-07-29
 
 ### Fixed

--- a/src/iPASide.Engine/ipaside_engine/__init__.py
+++ b/src/iPASide.Engine/ipaside_engine/__init__.py
@@ -11,4 +11,4 @@ This package is intentionally usable stand-alone as a CLI:
     python -m ipaside_engine devices
 """
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/src/iPASide.Engine/ipaside_engine/anisette.py
+++ b/src/iPASide.Engine/ipaside_engine/anisette.py
@@ -18,6 +18,8 @@ Apple ID information is in anisette data, and none is sent to the library host.
 from __future__ import annotations
 
 import io
+import locale
+from datetime import datetime, timedelta, timezone
 from importlib import metadata
 from typing import Any
 
@@ -104,10 +106,75 @@ def _load_provider() -> Any:
     return provider
 
 
+def _gmt_offset_label(offset: timedelta) -> str:
+    """Format a UTC offset the way Apple clients do when they have no abbreviation."""
+    total = int(offset.total_seconds())
+    sign = "+" if total >= 0 else "-"
+    total = abs(total)
+    hours, rem = divmod(total, 3600)
+    minutes = rem // 60
+    return f"GMT{sign}{hours:02d}:{minutes:02d}"
+
+
+def ascii_timezone(now: datetime | None = None) -> str:
+    """Timezone label safe to put on an HTTP header.
+
+    The ``anisette`` package uses ``str(tzinfo)``, which on Windows is the *localized*
+    display name - ``India Standard Time`` in English, ``中国标准时间`` on a Chinese
+    install. HTTP headers are latin-1 (urllib3 encodes them that way), so a CJK name
+    raises ``UnicodeEncodeError`` the moment sign-in reaches the trusted-device 2FA
+    request that carries anisette as headers. Apple's own clients send an abbreviation
+    (``PDT``, ``CST``) or a ``GMT±HH:MM`` offset - both ASCII - so that is what we emit.
+    """
+    when = now if now is not None else datetime.now().astimezone()
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+
+    name = when.tzname() or ""
+    if name.isascii() and name.strip():
+        return name.strip()
+
+    offset = when.utcoffset()
+    if offset is None:
+        return "GMT"
+    return _gmt_offset_label(offset)
+
+
+def ascii_locale(preferred: str | None = None) -> str:
+    """Locale tag safe to put on an HTTP header.
+
+    Falls back to ``en_US`` when the process locale is missing or not latin-1, because a
+    localized Windows locale name can contain the same non-ASCII characters as the
+    timezone display name and would fail the same way on the wire.
+    """
+    candidate = preferred if preferred is not None else (locale.getlocale()[0] or "")
+    if candidate and candidate.isascii():
+        return candidate
+    return "en_US"
+
+
+def _wire_safe_headers(raw: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite anisette fields that must survive latin-1 HTTP header encoding.
+
+    Only ``X-Apple-I-TimeZone`` and ``X-Apple-Locale`` are known to come from the OS as
+    localized strings; every other anisette value is already ASCII (base64, UUIDs, ISO
+    timestamps). Rewriting them here - at the single place every caller goes through -
+    covers GrandSlam 2FA, developer services, and anything else that dumps anisette into
+    request headers, without each of those sites having to remember.
+    """
+    headers = dict(raw)
+    headers["X-Apple-I-TimeZone"] = ascii_timezone()
+    existing_locale = headers.get("X-Apple-Locale")
+    headers["X-Apple-Locale"] = ascii_locale(
+        existing_locale if isinstance(existing_locale, str) else None
+    )
+    return headers
+
+
 def get_headers() -> dict[str, Any]:
     """Return a fresh set of anisette headers for a GSA request."""
     provider = _load_provider()
-    return dict(provider.get_data())
+    return _wire_safe_headers(dict(provider.get_data()))
 
 
 def status() -> dict[str, Any]:

--- a/src/iPASide.Flutter/lib/app_version.dart
+++ b/src/iPASide.Flutter/lib/app_version.dart
@@ -4,4 +4,4 @@
 /// in a plugin, so it is mirrored here and `test/app_version_test.dart` fails the
 /// build if the two ever drift — a stale value would make the updater compare
 /// against the wrong version and either nag forever or never offer an update.
-const String kAppVersion = '1.1.2';
+const String kAppVersion = '1.1.3';

--- a/src/iPASide.Flutter/pubspec.yaml
+++ b/src/iPASide.Flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.2+3
+version: 1.1.3+4
 
 environment:
   sdk: ^3.12.2

--- a/tests/test_anisette_headers.py
+++ b/tests/test_anisette_headers.py
@@ -1,0 +1,183 @@
+"""Anisette headers must be safe to put on an HTTP wire.
+
+HTTP libraries (urllib3 via requests) encode header values as latin-1. The
+upstream ``anisette`` package fills ``X-Apple-I-TimeZone`` from ``str(tzinfo)``,
+which on a non-English Windows install is a localized display name - on Chinese
+Windows, ``中国标准时间`` (exactly six characters). Putting that on a request
+raises::
+
+    UnicodeEncodeError: 'latin-1' codec can't encode characters in position 0-5
+
+which is what blocked Apple ID sign-in for a reporter on engine 1.1.2 (GitHub
+issue #3): GrandSlam SRP succeeded, then the trusted-device 2FA trigger dumped
+every anisette field into request headers and died. These tests pin the
+sanitiser that rewrites timezone/locale to ASCII, and prove a 2FA-shaped
+request with the bad value fails while the sanitised one does not.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from ipaside_engine import anisette, gsa
+
+
+# The exact timezone display name Chinese Windows returns for China Standard Time.
+# Six characters: UnicodeEncodeError reports "position 0-5".
+_CHINESE_TZ = "中国标准时间"
+_CHINESE_LOCALE = "中文_中国"
+
+
+def test_chinese_timezone_is_not_latin1() -> None:
+    """Document the OS value that breaks urllib3, so a regression is obvious."""
+    with pytest.raises(UnicodeEncodeError, match="latin-1") as caught:
+        _CHINESE_TZ.encode("latin-1")
+    assert caught.value.start == 0
+    assert caught.value.end == 6
+
+
+def test_ascii_timezone_prefers_abbreviation_when_ascii() -> None:
+    tz = timezone(timedelta(hours=5, minutes=30), name="India Standard Time")
+    when = datetime(2026, 7, 31, 12, 0, tzinfo=tz)
+    assert anisette.ascii_timezone(when) == "India Standard Time"
+
+
+def test_ascii_timezone_falls_back_to_gmt_offset_for_cjk_name() -> None:
+    tz = timezone(timedelta(hours=8), name=_CHINESE_TZ)
+    when = datetime(2026, 7, 31, 12, 0, tzinfo=tz)
+    assert anisette.ascii_timezone(when) == "GMT+08:00"
+    anisette.ascii_timezone(when).encode("latin-1")  # must not raise
+
+
+def test_ascii_timezone_negative_offset() -> None:
+    tz = timezone(-timedelta(hours=5), name="hora estándar de América del Este")
+    when = datetime(2026, 1, 15, 12, 0, tzinfo=tz)
+    assert anisette.ascii_timezone(when) == "GMT-05:00"
+
+
+def test_ascii_locale_keeps_ascii_and_falls_back_otherwise() -> None:
+    assert anisette.ascii_locale("English_India") == "English_India"
+    assert anisette.ascii_locale("zh_CN") == "zh_CN"
+    assert anisette.ascii_locale(_CHINESE_LOCALE) == "en_US"
+    assert anisette.ascii_locale("") == "en_US"
+    # None means "ask the process"; whatever it returns must be wire-safe.
+    assert anisette.ascii_locale(None).isascii()
+
+
+def test_wire_safe_headers_rewrite_localized_os_fields() -> None:
+    raw = {
+        "X-Apple-I-MD": "AAAABQ==",
+        "X-Apple-I-TimeZone": _CHINESE_TZ,
+        "X-Apple-Locale": _CHINESE_LOCALE,
+        "X-MMe-Client-Info": "<MacBookPro13,2> <macOS;13.1;22C65> <com.apple.AuthKit/1>",
+    }
+    safe = anisette._wire_safe_headers(raw)
+    assert safe["X-Apple-I-TimeZone"] != _CHINESE_TZ
+    assert safe["X-Apple-I-TimeZone"].isascii()
+    assert safe["X-Apple-Locale"].isascii()
+    assert safe["X-Apple-I-MD"] == "AAAABQ=="
+    for value in safe.values():
+        if isinstance(value, str):
+            value.encode("latin-1")
+
+
+def test_twofa_request_with_chinese_timezone_raises_without_sanitiser() -> None:
+    """Reproduce issue #3: urllib3 dies encoding the localized timezone as a header."""
+    bad = {
+        "X-Apple-I-Client-Time": "2026-07-31T15:30:32+08:00Z",
+        "X-Apple-I-MD": "AAAABQAAABBAkppa4y0mtsmoC3gVqnNCAAAABA==",
+        "X-Apple-I-MD-LU": "NTY2Qjg3",
+        "X-Apple-I-MD-M": "IoQPIo33",
+        "X-Apple-I-MD-RINFO": "17106176",
+        "X-Apple-I-SRL-NO": "0",
+        "X-Apple-I-TimeZone": _CHINESE_TZ,
+        "X-Apple-Locale": "zh_CN",
+        "X-MMe-Client-Info": (
+            "<MacBookPro13,2> <macOS;13.1;22C65> "
+            "<com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>"
+        ),
+        "X-Mme-Device-Id": "F718CB6B-8090-4AA6-9D92-1FB9AA417A0E",
+    }
+    headers = gsa._twofa_headers("adsid", "token", bad)
+    with pytest.raises(UnicodeEncodeError, match="latin-1"):
+        # httpbin is unused: the encode fails while building the wire request,
+        # before any bytes leave the machine.
+        requests.get(
+            "https://httpbin.org/headers",
+            headers=headers,
+            timeout=5,
+        )
+
+
+def test_twofa_request_with_sanitised_headers_encodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After sanitising, the same 2FA-shaped request is latin-1 clean."""
+    raw = {
+        "X-Apple-I-Client-Time": "2026-07-31T15:30:32+08:00Z",
+        "X-Apple-I-MD": "AAAABQAAABBAkppa4y0mtsmoC3gVqnNCAAAABA==",
+        "X-Apple-I-MD-LU": "NTY2Qjg3",
+        "X-Apple-I-MD-M": "IoQPIo33",
+        "X-Apple-I-MD-RINFO": "17106176",
+        "X-Apple-I-SRL-NO": "0",
+        "X-Apple-I-TimeZone": _CHINESE_TZ,
+        "X-Apple-Locale": _CHINESE_LOCALE,
+        "X-MMe-Client-Info": (
+            "<MacBookPro13,2> <macOS;13.1;22C65> "
+            "<com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>"
+        ),
+        "X-Mme-Device-Id": "F718CB6B-8090-4AA6-9D92-1FB9AA417A0E",
+    }
+    monkeypatch.setattr(
+        anisette,
+        "ascii_timezone",
+        lambda now=None: anisette._gmt_offset_label(timedelta(hours=8)),
+    )
+    safe = anisette._wire_safe_headers(raw)
+    assert safe["X-Apple-I-TimeZone"] == "GMT+08:00"
+    assert safe["X-Apple-Locale"] == "en_US"
+
+    headers = gsa._twofa_headers("adsid", "token", safe)
+    captured: dict[str, str] = {}
+
+    def fake_get(url: str, headers: dict[str, str] | None = None, **kwargs: object) -> MagicMock:
+        assert headers is not None
+        for key, value in headers.items():
+            value.encode("latin-1")
+            captured[key] = value
+        response = MagicMock()
+        response.status_code = 200
+        response.content = b""
+        return response
+
+    monkeypatch.setattr(gsa.requests, "get", fake_get)
+    gsa._trigger_trusted("adsid", "token", safe)
+    assert captured["X-Apple-I-TimeZone"] == "GMT+08:00"
+    assert "中国" not in captured["X-Apple-I-TimeZone"]
+
+
+def test_get_headers_returns_latin1_safe_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end through get_headers: provider may emit CJK, caller must not see it."""
+
+    class FakeProvider:
+        def get_data(self) -> dict[str, str]:
+            return {
+                "X-Apple-I-TimeZone": _CHINESE_TZ,
+                "X-Apple-Locale": _CHINESE_LOCALE,
+                "X-Apple-I-MD": "AAAABQ==",
+            }
+
+    monkeypatch.setattr(anisette, "_load_provider", lambda: FakeProvider())
+    monkeypatch.setattr(
+        anisette,
+        "ascii_timezone",
+        lambda now=None: "GMT+08:00",
+    )
+    headers = anisette.get_headers()
+    assert headers["X-Apple-I-TimeZone"] == "GMT+08:00"
+    assert headers["X-Apple-Locale"] == "en_US"
+    for value in headers.values():
+        if isinstance(value, str):
+            value.encode("latin-1")


### PR DESCRIPTION
## What

Fixes [#3](https://github.com/pwnapplehat/iPASide/issues/3): Apple ID sign-in fails on non-English Windows with `'latin-1' codec can't encode characters in position 0-5`.

### Root cause
After SRP succeeds, trusted-device 2FA puts anisette fields on the HTTP request. The upstream anisette package sets `X-Apple-I-TimeZone` from the OS timezone *display name* — on Chinese Windows that is `中国标准时间` (exactly 6 characters). urllib3 encodes HTTP headers as latin-1 and raises. The reporter stayed on the sign-in form with that error.

### Fix
`anisette.get_headers()` rewrites timezone/locale to ASCII Apple-style values (abbreviation or `GMT±HH:MM`, ASCII locale) so GrandSlam 2FA and developer services stay wire-safe.

### Verified
- Reproduced the exact `UnicodeEncodeError` / latin-1 / positions 0–5 with `中国标准时间` in 2FA-shaped headers.
- 9 new regression tests in `tests/test_anisette_headers.py` (including one that asserts the unsanitized path still raises).
- Full engine suite green.
