### PR TITLE
1.1.4: fix Apple 2FA on Chinese Windows (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to iPASide are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and
 [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.1.4] - 2026-08-01
+
+### Fixed
+
+- **On Chinese Windows, Apple ID sign-in showed the 2FA code screen but no code
+  ever arrived on the phone** ([#5](https://github.com/pwnapplehat/iPASide/issues/5)).
+  1.1.3 fixed the latin-1 crash from issue #3 by keeping ASCII timezone/locale
+  values, but Windows locale *display names* like ``Chinese (Simplified)_China``
+  are ASCII and were left unchanged. Apple's trusted-device endpoint answers
+  **HTTP 500** for that value and never pushes a code - proven live against
+  ``gsa.apple.com`` (same request with ``zh_CN`` returns 200). Locales are now
+  mapped to Apple-style tags (``zh_CN``, ``en_US``, …), and if Apple rejects the
+  2FA trigger the app reports that instead of claiming a code was sent.
+
 ## [1.1.3] - 2026-07-31
 
 ### Fixed

--- a/src/iPASide.Engine/ipaside_engine/__init__.py
+++ b/src/iPASide.Engine/ipaside_engine/__init__.py
@@ -11,4 +11,4 @@ This package is intentionally usable stand-alone as a CLI:
     python -m ipaside_engine devices
 """
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"

--- a/src/iPASide.Engine/ipaside_engine/anisette.py
+++ b/src/iPASide.Engine/ipaside_engine/anisette.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import io
 import locale
+import re
 from datetime import datetime, timedelta, timezone
 from importlib import metadata
 from typing import Any
@@ -45,6 +46,47 @@ _LIBS_URLS: tuple[str, ...] = (
 #: so it fails with a clear message rather than a cryptic "not a gzip/tar file" much later.
 _ARCHIVE_MAGIC = (b"PK", b"\x1f\x8b", b"BZh", b"\xfd7zXZ")
 
+#: Apple-style locale tags look like ``zh_CN`` / ``en_US`` (SideStore sends
+#: ``Locale.current.identifier``). The anisette package uses ``locale.getlocale()``, which
+#: on Windows is a *display* name like ``Chinese (Simplified)_China`` - ASCII, so it
+#: survives latin-1 encoding, but Apple's trusted-device 2FA endpoint answers HTTP 500 for
+#: it and never pushes a code (GitHub issue #5, proven live against gsa.apple.com).
+_APPLE_LOCALE = re.compile(r"^[A-Za-z]{2,3}([_-][A-Za-z0-9]+)+$")
+
+#: Windows ``getlocale()`` display names -> the identifier Apple's clients send.
+_WINDOWS_LOCALE_TO_APPLE: dict[str, str] = {
+    "chinese (simplified)_china": "zh_CN",
+    "chinese (simplified)_singapore": "zh_SG",
+    "chinese (traditional)_taiwan": "zh_TW",
+    "chinese (traditional)_hong kong s.a.r.": "zh_HK",
+    "chinese (traditional)_hong kong sar": "zh_HK",
+    "chinese (traditional)_macao s.a.r.": "zh_MO",
+    "chinese_china": "zh_CN",
+    "chinese_taiwan": "zh_TW",
+    "english_united states": "en_US",
+    "english_united kingdom": "en_GB",
+    "english_india": "en_IN",
+    "english_australia": "en_AU",
+    "english_canada": "en_CA",
+    "japanese_japan": "ja_JP",
+    "korean_korea": "ko_KR",
+    "german_germany": "de_DE",
+    "french_france": "fr_FR",
+    "french_canada": "fr_CA",
+    "spanish_spain": "es_ES",
+    "spanish_mexico": "es_MX",
+    "portuguese_brazil": "pt_BR",
+    "portuguese_portugal": "pt_PT",
+    "russian_russia": "ru_RU",
+    "italian_italy": "it_IT",
+    "dutch_netherlands": "nl_NL",
+    "polish_poland": "pl_PL",
+    "turkish_turkey": "tr_TR",
+    "thai_thailand": "th_TH",
+    "vietnamese_vietnam": "vi_VN",
+    "arabic_saudi arabia": "ar_SA",
+    "hindi_india": "hi_IN",
+}
 
 def _download_libs() -> io.BytesIO:
     """Fetch Apple's provisioning libraries, trying each source with retries.
@@ -141,26 +183,67 @@ def ascii_timezone(now: datetime | None = None) -> str:
 
 
 def ascii_locale(preferred: str | None = None) -> str:
-    """Locale tag safe to put on an HTTP header.
+    """Locale tag Apple's GrandSlam endpoints accept on the wire.
 
-    Falls back to ``en_US`` when the process locale is missing or not latin-1, because a
-    localized Windows locale name can contain the same non-ASCII characters as the
-    timezone display name and would fail the same way on the wire.
+    Must be both latin-1-safe *and* an identifier Apple understands. Keeping a Windows
+    display name just because it is ASCII is not enough: ``Chinese (Simplified)_China``
+    encodes fine, then ``/auth/verify/trusteddevice`` returns HTTP 500 and no code is
+    pushed to the phone (issue #5, reproduced live). Map Windows names to Apple-style
+    tags (``zh_CN``), accept tags that already look like ``zh_CN`` / ``en_US``, and fall
+    back to ``en_US``.
     """
-    candidate = preferred if preferred is not None else (locale.getlocale()[0] or "")
-    if candidate and candidate.isascii():
-        return candidate
+    candidates: list[str] = []
+    if preferred:
+        candidates.append(preferred)
+    # Windows often exposes the POSIX tag here (zh_CN / en_IN) even when getlocale()
+    # returns the localized display form the anisette package copies into headers.
+    try:
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            default = locale.getdefaultlocale()[0]
+    except Exception:  # noqa: BLE001 - locale stack varies by platform
+        default = None
+    if default:
+        candidates.append(default)
+    try:
+        current = locale.getlocale()[0]
+    except Exception:  # noqa: BLE001
+        current = None
+    if current:
+        candidates.append(current)
+
+    for candidate in candidates:
+        mapped = _apple_locale_tag(candidate)
+        if mapped:
+            return mapped
     return "en_US"
 
 
-def _wire_safe_headers(raw: dict[str, Any]) -> dict[str, Any]:
-    """Rewrite anisette fields that must survive latin-1 HTTP header encoding.
+def _apple_locale_tag(value: str) -> str | None:
+    """Return an Apple-style locale tag for ``value``, or None if it cannot be mapped."""
+    if not value or not value.isascii():
+        return None
+    cleaned = value.strip().replace("-", "_")
+    if _APPLE_LOCALE.fullmatch(cleaned):
+        # Normalise script/region casing lightly: zh_cn -> zh_CN when 2-letter region.
+        parts = cleaned.split("_")
+        if len(parts) >= 2 and len(parts[1]) == 2:
+            parts[1] = parts[1].upper()
+        parts[0] = parts[0].lower()
+        return "_".join(parts)
+    return _WINDOWS_LOCALE_TO_APPLE.get(value.strip().lower())
 
-    Only ``X-Apple-I-TimeZone`` and ``X-Apple-Locale`` are known to come from the OS as
-    localized strings; every other anisette value is already ASCII (base64, UUIDs, ISO
-    timestamps). Rewriting them here - at the single place every caller goes through -
+
+def _wire_safe_headers(raw: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite anisette fields that must be both latin-1-safe and Apple-accepted.
+
+    ``X-Apple-I-TimeZone`` and ``X-Apple-Locale`` come from the OS as localized or
+    Windows-display strings. Every other anisette value is already ASCII (base64, UUIDs,
+    ISO timestamps). Rewriting them here - at the single place every caller goes through -
     covers GrandSlam 2FA, developer services, and anything else that dumps anisette into
-    request headers, without each of those sites having to remember.
+    request headers.
     """
     headers = dict(raw)
     headers["X-Apple-I-TimeZone"] = ascii_timezone()
@@ -169,7 +252,6 @@ def _wire_safe_headers(raw: dict[str, Any]) -> dict[str, Any]:
         existing_locale if isinstance(existing_locale, str) else None
     )
     return headers
-
 
 def get_headers() -> dict[str, Any]:
     """Return a fresh set of anisette headers for a GSA request."""

--- a/src/iPASide.Engine/ipaside_engine/gsa.py
+++ b/src/iPASide.Engine/ipaside_engine/gsa.py
@@ -199,12 +199,24 @@ def _twofa_headers(adsid: str, idms_token: str, headers: dict[str, str]) -> dict
 
 
 def _trigger_trusted(adsid: str, idms_token: str, headers: dict[str, str]) -> None:
-    requests.get(
+    """Ask Apple to push a trusted-device 2FA code.
+
+    The response body is an HTML interstitial even on success, so status is the signal.
+    Ignoring a non-2xx (as we used to) is what made issue #5 look like "code was sent"
+    in the UI while Apple had actually rejected the request with HTTP 500 over a bad
+    ``X-Apple-Locale``.
+    """
+    resp = requests.get(
         _TRUSTED_TRIGGER,
         headers=_twofa_headers(adsid, idms_token, headers),
         timeout=_TIMEOUT,
         verify=tls.ca_bundle(),
     )
+    if resp.status_code != 200:
+        raise GsaError(
+            f"Apple did not send a verification code (HTTP {resp.status_code}). "
+            "Check your connection and try signing in again."
+        )
 
 
 def _submit_trusted(adsid: str, idms_token: str, code: str, headers: dict[str, str]) -> None:

--- a/src/iPASide.Flutter/lib/app_version.dart
+++ b/src/iPASide.Flutter/lib/app_version.dart
@@ -4,4 +4,4 @@
 /// in a plugin, so it is mirrored here and `test/app_version_test.dart` fails the
 /// build if the two ever drift — a stale value would make the updater compare
 /// against the wrong version and either nag forever or never offer an update.
-const String kAppVersion = '1.1.3';
+const String kAppVersion = '1.1.4';

--- a/src/iPASide.Flutter/pubspec.yaml
+++ b/src/iPASide.Flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.3+4
+version: 1.1.4+5
 
 environment:
   sdk: ^3.12.2

--- a/tests/test_anisette_headers.py
+++ b/tests/test_anisette_headers.py
@@ -59,26 +59,34 @@ def test_ascii_timezone_negative_offset() -> None:
     assert anisette.ascii_timezone(when) == "GMT-05:00"
 
 
-def test_ascii_locale_keeps_ascii_and_falls_back_otherwise() -> None:
-    assert anisette.ascii_locale("English_India") == "English_India"
+def test_ascii_locale_maps_windows_display_names_to_apple_tags() -> None:
+    # Issue #5: this exact Windows value is ASCII but Apple answers HTTP 500 for it.
+    assert anisette.ascii_locale("Chinese (Simplified)_China") == "zh_CN"
+    assert anisette.ascii_locale("Chinese (Traditional)_Taiwan") == "zh_TW"
+    assert anisette.ascii_locale("English_India") == "en_IN"
+    assert anisette.ascii_locale("English_United States") == "en_US"
     assert anisette.ascii_locale("zh_CN") == "zh_CN"
-    assert anisette.ascii_locale(_CHINESE_LOCALE) == "en_US"
-    assert anisette.ascii_locale("") == "en_US"
-    # None means "ask the process"; whatever it returns must be wire-safe.
-    assert anisette.ascii_locale(None).isascii()
+    assert anisette.ascii_locale("zh-Hans-CN") == "zh_Hans_CN"
+    cjk_fallback = anisette.ascii_locale(_CHINESE_LOCALE)
+    assert cjk_fallback.isascii()
+    assert anisette._APPLE_LOCALE.fullmatch(cjk_fallback)
+    # Empty / None consult the process locale; must still be an Apple-style tag.
+    assert anisette._APPLE_LOCALE.fullmatch(anisette.ascii_locale(""))
+    assert anisette._APPLE_LOCALE.fullmatch(anisette.ascii_locale(None))
+    assert anisette.ascii_locale("Chinese (Simplified)_China") == "zh_CN"
 
 
 def test_wire_safe_headers_rewrite_localized_os_fields() -> None:
     raw = {
         "X-Apple-I-MD": "AAAABQ==",
         "X-Apple-I-TimeZone": _CHINESE_TZ,
-        "X-Apple-Locale": _CHINESE_LOCALE,
+        "X-Apple-Locale": "Chinese (Simplified)_China",
         "X-MMe-Client-Info": "<MacBookPro13,2> <macOS;13.1;22C65> <com.apple.AuthKit/1>",
     }
     safe = anisette._wire_safe_headers(raw)
     assert safe["X-Apple-I-TimeZone"] != _CHINESE_TZ
     assert safe["X-Apple-I-TimeZone"].isascii()
-    assert safe["X-Apple-Locale"].isascii()
+    assert safe["X-Apple-Locale"] == "zh_CN"
     assert safe["X-Apple-I-MD"] == "AAAABQ=="
     for value in safe.values():
         if isinstance(value, str):
@@ -123,7 +131,7 @@ def test_twofa_request_with_sanitised_headers_encodes(monkeypatch: pytest.Monkey
         "X-Apple-I-MD-RINFO": "17106176",
         "X-Apple-I-SRL-NO": "0",
         "X-Apple-I-TimeZone": _CHINESE_TZ,
-        "X-Apple-Locale": _CHINESE_LOCALE,
+        "X-Apple-Locale": "Chinese (Simplified)_China",
         "X-MMe-Client-Info": (
             "<MacBookPro13,2> <macOS;13.1;22C65> "
             "<com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>"
@@ -137,7 +145,7 @@ def test_twofa_request_with_sanitised_headers_encodes(monkeypatch: pytest.Monkey
     )
     safe = anisette._wire_safe_headers(raw)
     assert safe["X-Apple-I-TimeZone"] == "GMT+08:00"
-    assert safe["X-Apple-Locale"] == "en_US"
+    assert safe["X-Apple-Locale"] == "zh_CN"
 
     headers = gsa._twofa_headers("adsid", "token", safe)
     captured: dict[str, str] = {}
@@ -158,6 +166,20 @@ def test_twofa_request_with_sanitised_headers_encodes(monkeypatch: pytest.Monkey
     assert "中国" not in captured["X-Apple-I-TimeZone"]
 
 
+def test_trigger_trusted_raises_on_http_500(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #5: never tell the UI a code was sent when Apple rejected the trigger."""
+
+    def fake_get(url: str, headers: dict[str, str] | None = None, **kwargs: object) -> MagicMock:
+        response = MagicMock()
+        response.status_code = 500
+        response.content = b""
+        return response
+
+    monkeypatch.setattr(gsa.requests, "get", fake_get)
+    with pytest.raises(gsa.GsaError, match="did not send a verification code"):
+        gsa._trigger_trusted("adsid", "token", {"X-Apple-Locale": "zh_CN"})
+
+
 def test_get_headers_returns_latin1_safe_values(monkeypatch: pytest.MonkeyPatch) -> None:
     """End-to-end through get_headers: provider may emit CJK, caller must not see it."""
 
@@ -165,7 +187,7 @@ def test_get_headers_returns_latin1_safe_values(monkeypatch: pytest.MonkeyPatch)
         def get_data(self) -> dict[str, str]:
             return {
                 "X-Apple-I-TimeZone": _CHINESE_TZ,
-                "X-Apple-Locale": _CHINESE_LOCALE,
+                "X-Apple-Locale": "Chinese (Simplified)_China",
                 "X-Apple-I-MD": "AAAABQ==",
             }
 
@@ -177,7 +199,20 @@ def test_get_headers_returns_latin1_safe_values(monkeypatch: pytest.MonkeyPatch)
     )
     headers = anisette.get_headers()
     assert headers["X-Apple-I-TimeZone"] == "GMT+08:00"
-    assert headers["X-Apple-Locale"] == "en_US"
+    assert headers["X-Apple-Locale"] == "zh_CN"
     for value in headers.values():
         if isinstance(value, str):
             value.encode("latin-1")
+
+
+def test_chinese_windows_locale_maps_away_from_apple_rejected_value() -> None:
+    """Pin the exact 1.1.3 regression: Windows locale kept, Apple returns 500."""
+    assert anisette._apple_locale_tag("Chinese (Simplified)_China") == "zh_CN"
+    raw = {
+        "X-Apple-I-MD": "AAAABQ==",
+        "X-Apple-I-TimeZone": "GMT+08:00",
+        "X-Apple-Locale": "Chinese (Simplified)_China",
+    }
+    safe = anisette._wire_safe_headers(raw)
+    assert safe["X-Apple-Locale"] == "zh_CN"
+    assert safe["X-Apple-Locale"] != "Chinese (Simplified)_China"


### PR DESCRIPTION
## What

Fixes #5. On Chinese Windows with 1.1.3, sign-in reaches the 2FA screen but Apple never sends a code.

## Root cause (live against Apple)

1.1.3 kept `Chinese (Simplified)_China` because it is ASCII (latin-1 safe). `gsa.apple.com/auth/verify/trusteddevice` returns **HTTP 500** for that locale. Same request with `zh_CN` returns **200**. `_trigger_trusted` ignored non-200, so the UI said a code was sent.

## Fix

- Map Windows locale display names to Apple-style tags (`zh_CN`, `en_US`, …)
- Raise a clear error when the 2FA trigger is rejected

## Verified

- Live Apple probe: 1.1.3 headers → 500; fixed → 200
- `_trigger_trusted` raises on 500
- Engine tests green